### PR TITLE
Run Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1821,7 @@ dependencies = [
  "postgres-native-tls",
  "postgres-types",
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1840,6 +1847,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "rstest",
+ "schemars",
  "serde",
  "test-log",
  "tracing",
@@ -2839,6 +2847,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,6 +3169,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +3268,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ parquet = { version = "58", features = ["async", "arrow", "object_store", "arrow
 postgres-native-tls = "0.5.3"
 postgres-types = "0.2.13"
 serde = { version = "1.0.228", features = ["serde_derive"] }
+schemars = "1.2.1"
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"
 tokio = { version = "1.52.1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/ldrs-arrow/Cargo.toml
+++ b/crates/ldrs-arrow/Cargo.toml
@@ -12,6 +12,7 @@ arrow-array.workspace = true
 arrow-schema.workspace = true
 anyhow.workspace = true
 chrono = "0.4.44"
+schemars.workspace = true
 serde.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/crates/ldrs-arrow/src/types.rs
+++ b/crates/ldrs-arrow/src/types.rs
@@ -1,6 +1,7 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub enum TimeUnit {
     Second,
     Millis,
@@ -87,7 +88,7 @@ impl<'a> ColumnSchema<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
 pub enum ColumnType {
     #[serde(alias = "VARCHAR")]
     Varchar(i32),
@@ -215,7 +216,7 @@ pub struct FileLoadData {
     pub path_parts: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(tag = "type")]
 pub enum ColumnSpec {
     #[serde(rename = "varchar", alias = "VARCHAR")]

--- a/crates/ldrs-arrow/src/types.rs
+++ b/crates/ldrs-arrow/src/types.rs
@@ -217,7 +217,7 @@ pub struct FileLoadData {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 pub enum ColumnSpec {
     #[serde(rename = "varchar", alias = "VARCHAR")]
     Varchar { name: String, length: i32 },

--- a/crates/ldrs/Cargo.toml
+++ b/crates/ldrs/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = "0.12.5"
 parquet.workspace = true
 postgres-native-tls.workspace = true
 postgres-types.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/ldrs/src/cli_schema.rs
+++ b/crates/ldrs/src/cli_schema.rs
@@ -1,0 +1,85 @@
+use anyhow::bail;
+use schemars::SchemaGenerator;
+use serde_json::{json, Value};
+
+use crate::{
+    delta::DeltaDestination,
+    file_source::FileSource,
+    ldrs_config::config::{ArrowDestination, LdrsConfig},
+    ldrs_snowflake::snowflake_source::SFSource,
+    parquet::ParquetDestination,
+    postgres::postgres_destination::PgDestination,
+};
+
+fn usage_block() -> Value {
+    json!({
+        "yaml_config": "The schemas under `sources` and `destinations` describe the per-table block shape used inside `tables:` in YAML config files. The full YAML envelope is documented under `yaml_config`. Defaults are merged into each table block; later table-level values override.",
+        "run_command": "`ldrs run` accepts a single block. Three layers, top wins: first-class flags (--src/--dest/--name/--sql) > --opt key=value pairs > --config-inline YAML. --opt is flat string=string only; complex (nested/list) fields require --config-inline.",
+        "namespacing": "If a kind has a `namespace` field, that string is an optional prefix on any of its type-specific fields (e.g., `pg.merge_keys` and `merge_keys` are equivalent for pg). Universal block fields (`name`, `src`, `dest`) are never namespaced. Used to disambiguate when source and destination contribute overlapping field names to the same block.",
+        "columns": "The `columns` field, when present on a destination kind, declares column transforms (rename/cast/projection). It is always a destination-side field — sources never accept `columns`.",
+        "env_vars": {
+            "LDRS_SRC": "URL for the source location. The scheme infers the source kind when --src is not passed: `snowflake://...` → sf, `delta+<scheme>://...` → delta, `postgres://...` → pg, object-store URLs (`s3://`, `gs://`, `az://`, `file://`, ...) → file.",
+            "LDRS_DEST": "URL for the destination location. Same scheme→kind inference as LDRS_SRC.",
+            "LDRS_PARAM_<NAME>[_<TYPE>]": "SQL parameter bindings consumed by query-shaped sources (e.g. sf.query). `LDRS_PARAM_P1=42` binds parameter `P1`. Append a type suffix to coerce: `LDRS_PARAM_P1_INT=42`.",
+            "LDRS_TEMPL_<NAME>": "Handlebars template variable. `LDRS_TEMPL_BUCKET=my-bucket` makes `{{ bucket }}` available inside templated string fields.",
+        },
+        "templating": "String fields can contain handlebars templates rendered against the execution context. `{{ name }}` expands to the name property; custom variables come from `LDRS_TEMPL_<NAME>` env vars. Common use: `filename: \"{{ name }}/{{ name }}.snappy.parquet\"` builds a per-table path.",
+        "examples": {
+            "snowflake_to_local_parquet": "LDRS_DEST=file:///tmp/probe ldrs run --src sf.query --dest pq --name probe --sql 'SELECT 1 AS x' --opt filename=probe.snappy.parquet",
+            "pipe_arrow_to_duckdb": "ldrs run --src sf.query --dest arrow --name probe --sql 'SELECT 1 AS x' | duckdb -c \"INSTALL nanoarrow FROM community; LOAD nanoarrow; FROM read_arrow('/dev/stdin')\"",
+            "pipe_arrow_to_pyarrow": "ldrs run --src sf.query --dest arrow --name probe --sql 'SELECT 1' | python3 -c 'import pyarrow.ipc, sys; print(pyarrow.ipc.open_stream(sys.stdin.buffer).read_all())'"
+        }
+    })
+}
+
+pub fn build_full() -> Value {
+    let mut g = SchemaGenerator::default();
+    let yaml_config = g.subschema_for::<LdrsConfig>();
+    let sources = json!({
+        "file": { "schema": g.subschema_for::<FileSource>() },
+        "sf": { "namespace": "sf", "schema": g.subschema_for::<SFSource>() },
+    });
+    let destinations = json!({
+        "pg": { "namespace": "pg", "schema": g.subschema_for::<PgDestination>() },
+        "pq": { "namespace": "pq", "schema": g.subschema_for::<ParquetDestination>() },
+        "delta": { "namespace": "delta", "schema": g.subschema_for::<DeltaDestination>() },
+        "arrow": { "schema": g.subschema_for::<ArrowDestination>() },
+    });
+    json!({
+        "usage": usage_block(),
+        "$defs": g.take_definitions(true),
+        "yaml_config": yaml_config,
+        "sources": sources,
+        "destinations": destinations,
+    })
+}
+
+pub fn build_one(kind: &str) -> Result<Value, anyhow::Error> {
+    let mut g = SchemaGenerator::default();
+    let source = match kind {
+        "file" => Some(json!({ "schema": g.subschema_for::<FileSource>() })),
+        "sf" => Some(json!({ "namespace": "sf", "schema": g.subschema_for::<SFSource>() })),
+        _ => None,
+    };
+    let destination = match kind {
+        "pg" => Some(json!({ "namespace": "pg", "schema": g.subschema_for::<PgDestination>() })),
+        "pq" => {
+            Some(json!({ "namespace": "pq", "schema": g.subschema_for::<ParquetDestination>() }))
+        }
+        "delta" => {
+            Some(json!({ "namespace": "delta", "schema": g.subschema_for::<DeltaDestination>() }))
+        }
+        "arrow" => Some(json!({ "schema": g.subschema_for::<ArrowDestination>() })),
+        _ => None,
+    };
+    if source.is_none() && destination.is_none() {
+        bail!("unknown kind: {}", kind);
+    }
+    Ok(json!({
+        "usage": usage_block(),
+        "$defs": g.take_definitions(true),
+        "kind": kind,
+        "source": source,
+        "destination": destination,
+    }))
+}

--- a/crates/ldrs/src/cli_schema.rs
+++ b/crates/ldrs/src/cli_schema.rs
@@ -27,7 +27,8 @@ fn usage_block() -> Value {
         "examples": {
             "snowflake_to_local_parquet": "LDRS_DEST=file:///tmp/probe ldrs run --src sf.query --dest pq --name probe --sql 'SELECT 1 AS x' --opt filename=probe.snappy.parquet",
             "pipe_arrow_to_duckdb": "ldrs run --src sf.query --dest arrow --name probe --sql 'SELECT 1 AS x' | duckdb -c \"INSTALL nanoarrow FROM community; LOAD nanoarrow; FROM read_arrow('/dev/stdin')\"",
-            "pipe_arrow_to_pyarrow": "ldrs run --src sf.query --dest arrow --name probe --sql 'SELECT 1' | python3 -c 'import pyarrow.ipc, sys; print(pyarrow.ipc.open_stream(sys.stdin.buffer).read_all())'"
+            "pipe_arrow_to_pyarrow": "ldrs run --src sf.query --dest arrow --name probe --sql 'SELECT 1' | python3 -c 'import pyarrow.ipc, sys; print(pyarrow.ipc.open_stream(sys.stdin.buffer).read_all())'",
+            "parameterized_sf_query": "LDRS_PARAM_P1=42 LDRS_PARAM_P2=2026-01-01 ldrs run --src sf.query --dest pq --name probe --sql 'SELECT * FROM t WHERE org_id = ? AND created_at >= ?' --config-inline 'param_keys: [P1, P2]' --opt filename=probe.parquet — note: env vars bind positionally in lexicographic order of the name, so zero-pad past nine (P01..P10) since lex order sorts P10 between P1 and P2"
         }
     })
 }

--- a/crates/ldrs/src/delta/mod.rs
+++ b/crates/ldrs/src/delta/mod.rs
@@ -1,30 +1,64 @@
 use ldrs_arrow::ColumnSpec;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub struct DeltaDestination {
-    pub name: String,
-    pub columns: Vec<ColumnSpec>,
-    pub max_rows: Option<usize>,
-    pub max_bytes: Option<usize>,
-    pub mode: DeltaMode,
+fn default_app_id() -> String {
+    "ldrs-merge-{{ name }}".to_string()
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub enum DeltaMode {
-    Overwrite,
-    Merge {
-        merge_keys: Vec<String>,
-        allow_null_keys: bool,
-        txn: Option<MergeTxnConfig>,
-    },
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DeltaCommon {
+    pub name: String,
+    #[serde(default, alias = "delta.columns")]
+    pub columns: Vec<ColumnSpec>,
+    #[serde(alias = "delta.max_rows")]
+    pub max_rows: Option<usize>,
+    #[serde(alias = "delta.max_bytes")]
+    pub max_bytes: Option<usize>,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TxnMode {
+    SourceWatermark,
+    ProcessingTime,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DeltaMerge {
+    #[serde(flatten)]
+    pub common: DeltaCommon,
+    #[serde(alias = "delta.merge_keys")]
+    pub merge_keys: Vec<String>,
+    #[serde(default, alias = "delta.allow_null_keys")]
+    pub allow_null_keys: bool,
+    #[serde(alias = "delta.txn_mode")]
+    pub txn_mode: Option<TxnMode>,
+    #[serde(alias = "delta.watermark_column")]
+    pub watermark_column: Option<String>,
+    #[serde(alias = "delta.batch_version")]
+    pub batch_version: Option<String>,
+    #[serde(default = "default_app_id", alias = "delta.app_id")]
+    pub app_id: String,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "dest")]
+#[schemars(
+    description = "Delta Lake destination. Writes to a table at LDRS_DEST + name; pick delta.overwrite or delta.merge for the operation."
+)]
+pub enum DeltaDestination {
+    #[serde(rename = "delta.overwrite")]
+    Overwrite(DeltaCommon),
+    #[serde(rename = "delta.merge")]
+    Merge(DeltaMerge),
 }
 
 /// Raw (unrendered) txn config from YAML. String templates are rendered at dispatch
 /// time against the execution context before constructing the runtime `TxnConfig`.
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum MergeTxnConfig {
     SourceWatermark {
         app_id: String,
@@ -42,230 +76,208 @@ fn get_ns<'a>(value: &'a Value, prefix: &str, key: &str) -> Option<&'a Value> {
     value.get(&ns_key).or(value.get(key))
 }
 
-impl TryFrom<&Value> for DeltaDestination {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        let name = value
-            .get("name")
-            .and_then(|v| String::deserialize(v).ok())
-            .ok_or(anyhow::anyhow!("Missing name"))?;
-        let columns = get_ns(value, "delta", "columns")
-            .and_then(|c| Vec::<ColumnSpec>::deserialize(c).ok())
-            .unwrap_or_default();
-        let max_rows = get_ns(value, "delta", "max_rows").and_then(|v| usize::deserialize(v).ok());
-        let max_bytes =
-            get_ns(value, "delta", "max_bytes").and_then(|v| usize::deserialize(v).ok());
-
-        // Merge mode detected by presence of merge_keys (namespaced or bare)
-        let mode = if let Some(keys_value) = get_ns(value, "delta", "merge_keys") {
-            let merge_keys = Vec::<String>::deserialize(keys_value)
-                .map_err(|e| anyhow::anyhow!("merge_keys must be a list of strings: {}", e))?;
-            if merge_keys.is_empty() {
+pub fn validate(value: &Value, parsed: &DeltaDestination) -> Result<(), anyhow::Error> {
+    match parsed {
+        DeltaDestination::Overwrite(_) => {
+            if get_ns(value, "delta", "merge_keys").is_some() {
+                anyhow::bail!("merge_keys not allowed with dest: delta.overwrite");
+            }
+        }
+        DeltaDestination::Merge(m) => {
+            if m.merge_keys.is_empty() {
                 anyhow::bail!("merge_keys cannot be empty");
             }
-
-            let allow_null_keys = get_ns(value, "delta", "allow_null_keys")
-                .and_then(|v| bool::deserialize(v).ok())
-                .unwrap_or(false);
-
-            let app_id = get_ns(value, "delta", "app_id")
-                .and_then(|v| String::deserialize(v).ok())
-                .unwrap_or_else(|| "ldrs-merge-{{ name }}".to_string());
-
-            let txn_mode =
-                get_ns(value, "delta", "txn_mode").and_then(|v| String::deserialize(v).ok());
-
-            let txn = match txn_mode.as_deref() {
-                Some("source_watermark") => {
-                    let watermark_column = get_ns(value, "delta", "watermark_column")
-                        .and_then(|v| String::deserialize(v).ok())
-                        .ok_or(anyhow::anyhow!(
-                            "source_watermark requires watermark_column"
-                        ))?;
-                    Some(MergeTxnConfig::SourceWatermark {
-                        app_id,
-                        watermark_column,
-                    })
-                }
-                Some("processing_time") => {
-                    let batch_version = get_ns(value, "delta", "batch_version")
-                        .and_then(|v| String::deserialize(v).ok());
-                    Some(MergeTxnConfig::ProcessingTime {
-                        app_id,
-                        batch_version,
-                    })
-                }
-                Some(other) => anyhow::bail!("unknown txn_mode: {}", other),
-                None => None,
-            };
-
-            DeltaMode::Merge {
-                merge_keys,
-                allow_null_keys,
-                txn,
+            if matches!(m.txn_mode, Some(TxnMode::SourceWatermark)) && m.watermark_column.is_none()
+            {
+                anyhow::bail!("source_watermark requires watermark_column");
             }
-        } else {
-            DeltaMode::Overwrite
-        };
-
-        Ok(DeltaDestination {
-            name,
-            columns,
-            max_rows,
-            max_bytes,
-            mode,
-        })
+        }
     }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn parse(yaml: &str) -> DeltaDestination {
-        let value: Value = serde_yaml::from_str(yaml).unwrap();
-        DeltaDestination::try_from(&value).unwrap()
+    fn parse_and_validate(yaml: &str) -> Result<DeltaDestination, anyhow::Error> {
+        let value: Value = serde_yaml::from_str(yaml)?;
+        let parsed: DeltaDestination = serde_yaml::from_value(value.clone())?;
+        validate(&value, &parsed)?;
+        Ok(parsed)
     }
 
     #[test]
-    fn overwrite_default_no_merge_keys() {
-        let dest = parse("name: public.users");
-        assert_eq!(dest.name, "public.users");
-        assert_eq!(dest.mode, DeltaMode::Overwrite);
-    }
-
-    #[test]
-    fn merge_mode_from_namespaced_keys() {
-        let dest = parse(
+    fn overwrite_bare() {
+        let dest = parse_and_validate(
             r#"
+dest: delta.overwrite
 name: public.users
-delta.merge_keys: [id]
-"#,
-        );
-        match dest.mode {
-            DeltaMode::Merge {
-                merge_keys,
-                allow_null_keys,
-                txn,
-            } => {
-                assert_eq!(merge_keys, vec!["id".to_string()]);
-                assert!(!allow_null_keys);
-                assert!(txn.is_none());
-            }
-            _ => panic!("expected Merge mode"),
-        }
-    }
-
-    #[test]
-    fn merge_mode_from_bare_keys() {
-        let dest = parse(
-            r#"
-name: public.users
-merge_keys: [id, name]
-"#,
-        );
-        match dest.mode {
-            DeltaMode::Merge { merge_keys, .. } => {
-                assert_eq!(merge_keys, vec!["id".to_string(), "name".to_string()]);
-            }
-            _ => panic!("expected Merge mode"),
-        }
-    }
-
-    #[test]
-    fn merge_source_watermark_parses() {
-        let dest = parse(
-            r#"
-name: public.users
-delta.merge_keys: [id]
-delta.txn_mode: source_watermark
-delta.watermark_column: updated_at
-delta.app_id: "my-app"
-"#,
-        );
-        match dest.mode {
-            DeltaMode::Merge {
-                txn:
-                    Some(MergeTxnConfig::SourceWatermark {
-                        app_id,
-                        watermark_column,
-                    }),
-                ..
-            } => {
-                assert_eq!(app_id, "my-app");
-                assert_eq!(watermark_column, "updated_at");
-            }
-            _ => panic!("expected SourceWatermark txn"),
-        }
-    }
-
-    #[test]
-    fn merge_processing_time_parses() {
-        let dest = parse(
-            r#"
-name: public.users
-delta.merge_keys: [id]
-delta.txn_mode: processing_time
-delta.batch_version: "{{ run_id }}"
-"#,
-        );
-        match dest.mode {
-            DeltaMode::Merge {
-                txn:
-                    Some(MergeTxnConfig::ProcessingTime {
-                        app_id,
-                        batch_version,
-                    }),
-                ..
-            } => {
-                // app_id defaulted to ldrs-merge-{{ name }} template (rendered later)
-                assert_eq!(app_id, "ldrs-merge-{{ name }}");
-                assert_eq!(batch_version.as_deref(), Some("{{ run_id }}"));
-            }
-            _ => panic!("expected ProcessingTime txn"),
-        }
-    }
-
-    #[test]
-    fn merge_allow_null_keys_parses() {
-        let dest = parse(
-            r#"
-name: public.users
-delta.merge_keys: [id]
-delta.allow_null_keys: true
-"#,
-        );
-        match dest.mode {
-            DeltaMode::Merge {
-                allow_null_keys, ..
-            } => assert!(allow_null_keys),
-            _ => panic!("expected Merge mode"),
-        }
-    }
-
-    #[test]
-    fn unknown_txn_mode_errors() {
-        let value: Value = serde_yaml::from_str(
-            r#"
-name: public.users
-delta.merge_keys: [id]
-delta.txn_mode: bogus
 "#,
         )
         .unwrap();
-        assert!(DeltaDestination::try_from(&value).is_err());
+        match dest {
+            DeltaDestination::Overwrite(c) => assert_eq!(c.name, "public.users"),
+            _ => panic!("expected Overwrite"),
+        }
+    }
+
+    #[test]
+    fn overwrite_namespaced_aliases() {
+        let dest = parse_and_validate(
+            r#"
+dest: delta.overwrite
+name: public.users
+delta.max_rows: 1000
+delta.max_bytes: 2000
+"#,
+        )
+        .unwrap();
+        match dest {
+            DeltaDestination::Overwrite(c) => {
+                assert_eq!(c.max_rows, Some(1000));
+                assert_eq!(c.max_bytes, Some(2000));
+            }
+            _ => panic!("expected Overwrite"),
+        }
+    }
+
+    #[test]
+    fn merge_bare() {
+        let dest = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+merge_keys: [id]
+"#,
+        )
+        .unwrap();
+        match dest {
+            DeltaDestination::Merge(m) => {
+                assert_eq!(m.common.name, "public.users");
+                assert_eq!(m.merge_keys, vec!["id".to_string()]);
+                assert!(!m.allow_null_keys);
+                assert!(m.txn_mode.is_none());
+            }
+            _ => panic!("expected Merge"),
+        }
+    }
+
+    #[test]
+    fn merge_namespaced_aliases() {
+        let dest = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+delta.merge_keys: [id, name]
+delta.allow_null_keys: true
+"#,
+        )
+        .unwrap();
+        match dest {
+            DeltaDestination::Merge(m) => {
+                assert_eq!(m.merge_keys, vec!["id".to_string(), "name".to_string()]);
+                assert!(m.allow_null_keys);
+            }
+            _ => panic!("expected Merge"),
+        }
+    }
+
+    #[test]
+    fn merge_source_watermark() {
+        let dest = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+merge_keys: [id]
+txn_mode: source_watermark
+watermark_column: updated_at
+app_id: my-app
+"#,
+        )
+        .unwrap();
+        match dest {
+            DeltaDestination::Merge(m) => {
+                assert_eq!(m.txn_mode, Some(TxnMode::SourceWatermark));
+                assert_eq!(m.watermark_column.as_deref(), Some("updated_at"));
+                assert_eq!(m.app_id, "my-app");
+            }
+            _ => panic!("expected Merge"),
+        }
+    }
+
+    #[test]
+    fn merge_processing_time() {
+        let dest = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+merge_keys: [id]
+txn_mode: processing_time
+batch_version: "{{ run_id }}"
+"#,
+        )
+        .unwrap();
+        match dest {
+            DeltaDestination::Merge(m) => {
+                assert_eq!(m.txn_mode, Some(TxnMode::ProcessingTime));
+                assert_eq!(m.batch_version.as_deref(), Some("{{ run_id }}"));
+                assert_eq!(m.app_id, "ldrs-merge-{{ name }}");
+            }
+            _ => panic!("expected Merge"),
+        }
+    }
+
+    #[test]
+    fn stray_merge_keys_on_overwrite_errors() {
+        let err = parse_and_validate(
+            r#"
+dest: delta.overwrite
+name: public.users
+merge_keys: [id]
+"#,
+        );
+        assert!(err.is_err(), "expected validate to reject stray merge_keys");
     }
 
     #[test]
     fn empty_merge_keys_errors() {
-        let value: Value = serde_yaml::from_str(
+        let err = parse_and_validate(
             r#"
+dest: delta.merge
 name: public.users
-delta.merge_keys: []
+merge_keys: []
 "#,
-        )
-        .unwrap();
-        assert!(DeltaDestination::try_from(&value).is_err());
+        );
+        assert!(err.is_err(), "expected validate to reject empty merge_keys");
+    }
+
+    #[test]
+    fn source_watermark_without_watermark_column_errors() {
+        let err = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+merge_keys: [id]
+txn_mode: source_watermark
+"#,
+        );
+        assert!(
+            err.is_err(),
+            "expected validate to require watermark_column"
+        );
+    }
+
+    #[test]
+    fn unknown_txn_mode_errors_at_parse() {
+        let err = parse_and_validate(
+            r#"
+dest: delta.merge
+name: public.users
+merge_keys: [id]
+txn_mode: bogus
+"#,
+        );
+        assert!(err.is_err(), "expected serde to reject unknown txn_mode");
     }
 }

--- a/crates/ldrs/src/file_source.rs
+++ b/crates/ldrs/src/file_source.rs
@@ -1,6 +1,10 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(
+    description = "Object-store source. Reads a file (typically Parquet) from LDRS_SRC + filename."
+)]
 pub struct FileSource {
     pub name: String,
     pub filename: Option<String>,
@@ -10,5 +14,16 @@ pub fn get_full_path(source: &FileSource) -> String {
     match &source.filename {
         Some(filename) => filename.clone(),
         None => source.name.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonschema_scratch_test() {
+        let schema = schemars::schema_for!(FileSource);
+        println!("{}", serde_json::to_string_pretty(&schema).unwrap());
     }
 }

--- a/crates/ldrs/src/ldrs_config/config.rs
+++ b/crates/ldrs/src/ldrs_config/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    delta::DeltaDestination,
+    delta::{self, DeltaDestination},
     file_source::FileSource,
     ldrs_snowflake::snowflake_source::{from_serde_yaml as from_sf_serde_yaml, SFSource},
     parquet::ParquetDestination,
@@ -7,17 +7,22 @@ use crate::{
 };
 
 use anyhow::Context;
+use ldrs_arrow::ColumnSpec;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct LdrsConfig {
     #[serde(default)]
     pub src: Option<String>,
+    #[schemars(with = "Option<serde_json::Value>")]
     pub src_defaults: Option<Value>,
     #[serde(default)]
     pub dest: Option<String>,
+    #[schemars(with = "Option<serde_json::Value>")]
     pub dest_defaults: Option<Value>,
+    #[schemars(with = "Vec<serde_json::Value>")]
     pub tables: Vec<serde_yaml::Value>,
 }
 
@@ -36,24 +41,33 @@ impl LdrsSource {
     }
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[schemars(
+    description = "Arrow IPC streaming destination. Writes the stream to stdout. Pipe to any Arrow IPC reader."
+)]
+pub struct ArrowDestination {
+    pub name: String,
+    #[serde(default)]
+    pub columns: Vec<ColumnSpec>,
+}
+
 #[derive(Debug, PartialEq)]
 pub enum LdrsDestination {
     Pg(PgDestination),
     Pq(ParquetDestination),
     Delta(DeltaDestination),
+    Arrow(ArrowDestination),
 }
 
 #[derive(Debug, PartialEq)]
 pub struct LdrsParsedConfig {
     pub src: LdrsSource,
-    pub src_prefix: String,
     pub dest: LdrsDestination,
-    pub dest_prefix: String,
 }
 
-fn merge_with_defaults(defaults: &Value, specific: Value) -> Value {
+pub fn merge_with_defaults(defaults: &Option<Value>, specific: Value) -> Value {
     match (defaults, specific) {
-        (Value::Mapping(def_map), Value::Mapping(mut spec_map)) => {
+        (Some(Value::Mapping(def_map)), Value::Mapping(mut spec_map)) => {
             for (k, v) in def_map {
                 spec_map.entry(k.clone()).or_insert(v.clone());
             }
@@ -63,14 +77,8 @@ fn merge_with_defaults(defaults: &Value, specific: Value) -> Value {
     }
 }
 
-pub fn get_parsed_config(
-    src_default: &Option<String>,
-    dest_default: &Option<String>,
-    src_default_value: &Option<Value>,
-    dest_default_value: &Option<Value>,
-    value: Value,
-) -> Result<LdrsParsedConfig, anyhow::Error> {
-    // first see if we have a src in the yaml value, that overrides
+/// Parses the src block of the config. The value here should already have defaults merged in.
+pub fn parse_src(value: Value, src_default: &Option<String>) -> Result<LdrsSource, anyhow::Error> {
     let src = value
         .get("src")
         .map(|v| String::deserialize(v))
@@ -79,27 +87,13 @@ pub fn get_parsed_config(
         .or(src_default.clone())
         .ok_or_else(|| anyhow::Error::msg("src is not set"))?;
 
-    let dest = value
-        .get("dest")
-        .map(|v| String::deserialize(v))
-        .transpose()
-        .map_err(|_| anyhow::Error::msg("dest is not correctly set in the table block"))?
-        .or(dest_default.clone())
-        .ok_or_else(|| anyhow::Error::msg("dest is not set"))?;
-
-    // get the prefix or the whole value
-    // and then insert it into the value and then parse it
     let src_prefix = src.split('.').next().unwrap_or(&src);
 
-    let dest_base = value.clone();
-    let mut src_value = match src_default_value {
-        Some(defaults) => merge_with_defaults(&defaults, value),
-        None => value,
-    };
+    let mut src_value = value;
     if let Value::Mapping(ref mut src_map) = src_value {
         src_map.insert(Value::String("src".to_string()), Value::String(src.clone()));
     }
-    let ldrs_src = match src_prefix {
+    match src_prefix {
         "file" => {
             let parsed: FileSource = serde_yaml::from_value(src_value)
                 .with_context(|| format!("failed to parse file source: {}", src))?;
@@ -111,74 +105,57 @@ pub fn get_parsed_config(
                 .or_else(|_| from_sf_serde_yaml(&src_value, Some(&src)))?;
             Ok(LdrsSource::SF(parsed))
         }
-        _ => Err(anyhow::Error::msg("unsupported src type")),
-    }?;
+        _ => Err(anyhow::Error::msg(
+            "unsupported src type (see `ldrs schema` for valid kinds)",
+        )),
+    }
+}
+
+/// Parses the dest block of the config. The value here should already have defaults merged in.
+pub fn parse_dest(
+    value: Value,
+    dest_default: &Option<String>,
+) -> Result<LdrsDestination, anyhow::Error> {
+    let dest = value
+        .get("dest")
+        .map(|v| String::deserialize(v))
+        .transpose()
+        .map_err(|_| anyhow::Error::msg("dest is not correctly set in the table block"))?
+        .or(dest_default.clone())
+        .ok_or_else(|| anyhow::Error::msg("dest is not set"))?;
 
     let dest_prefix = dest.split('.').next().unwrap_or(&dest);
-    let mut dest_value = match dest_default_value {
-        Some(defaults) => merge_with_defaults(&defaults, dest_base),
-        None => dest_base,
-    };
-    if let Value::Mapping(ref mut dest_map) = dest_value {
+    let mut value = value;
+    if let Value::Mapping(ref mut dest_map) = value {
         dest_map.insert(
             Value::String("dest".to_string()),
             Value::String(dest.clone()),
         );
     }
-    let ldrs_dest = match dest_prefix {
+    match dest_prefix {
         "pg" => {
-            let parsed = serde_yaml::from_value::<PgDestination>(dest_value.clone())
+            let parsed = serde_yaml::from_value::<PgDestination>(value.clone())
                 .with_context(|| format!("failed to parse pg destination: {}", dest))
-                .or_else(|_| from_serde_yaml(&dest_value, Some(&dest)))?;
+                .or_else(|_| from_serde_yaml(&value, Some(&dest)))?;
             Ok(LdrsDestination::Pg(parsed))
         }
         "pq" => {
-            let parsed = ParquetDestination::try_from(&dest_value)?;
+            let parsed = ParquetDestination::try_from(&value)?;
             Ok(LdrsDestination::Pq(parsed))
         }
         "delta" => {
-            let parsed = DeltaDestination::try_from(&dest_value)?;
+            let parsed: DeltaDestination = serde_yaml::from_value(value.clone())
+                .with_context(|| format!("failed to parse delta destination: {}", dest))?;
+            delta::validate(&value, &parsed)?;
             Ok(LdrsDestination::Delta(parsed))
         }
-        _ => Err(anyhow::Error::msg("unsupported dest type")),
-    }?;
-
-    Ok(LdrsParsedConfig {
-        src: ldrs_src,
-        src_prefix: src_prefix.to_string(),
-        dest: ldrs_dest,
-        dest_prefix: dest_prefix.to_string(),
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_config_parse() {
-        let config_yaml = r#"
-src: file
-dest: pg
-
-tables:
-    - name: public.users
-      merge_keys: [id]
-    - name: public.users
-      dest: pg.drop_replace
-      filename: public.users
-      post_sql:
-        - create index if not exists on {{ name }} (id);
-    - name: public.strings
-      dest: pg.drop_replace
-      post_sql:
-        - create index if not exists on {{ name }} (ok);
-"#;
-        let config: LdrsConfig = serde_yaml::from_str(config_yaml).unwrap();
-        // parse each table
-        for table in config.tables {
-            let parsed = get_parsed_config(&config.src, &config.dest, &None, &None, table);
-            println!("{:?}", parsed);
+        "arrow" => {
+            let parsed = serde_yaml::from_value::<ArrowDestination>(value.clone())
+                .with_context(|| format!("failed to parse arrow destination: {}", dest))?;
+            Ok(LdrsDestination::Arrow(parsed))
         }
+        _ => Err(anyhow::Error::msg(
+            "unsupported dest type (see `ldrs schema` for valid kinds)",
+        )),
     }
 }

--- a/crates/ldrs/src/ldrs_config/config.rs
+++ b/crates/ldrs/src/ldrs_config/config.rs
@@ -1,10 +1,17 @@
 use crate::{
-    delta::{self, DeltaDestination},
+    delta::{self, DeltaCommon, DeltaDestination, DeltaMerge},
     file_source::FileSource,
-    ldrs_snowflake::snowflake_source::{from_serde_yaml as from_sf_serde_yaml, SFSource},
+    ldrs_config::field_validation::{extract_props, find_unknown_keys, UnknownKey},
+    ldrs_snowflake::snowflake_source::{
+        from_serde_yaml as from_sf_serde_yaml, SFQuery, SFSource, SFTable,
+    },
     parquet::ParquetDestination,
-    postgres::postgres_destination::{from_serde_yaml, PgDestination},
+    postgres::postgres_destination::{
+        from_serde_yaml, PgCommon, PgDeleteInsert, PgDestination, PgMerge,
+    },
 };
+
+use std::collections::HashSet;
 
 use anyhow::Context;
 use ldrs_arrow::ColumnSpec;
@@ -63,6 +70,54 @@ pub enum LdrsDestination {
 pub struct LdrsParsedConfig {
     pub src: LdrsSource,
     pub dest: LdrsDestination,
+    pub unknown_keys: Vec<UnknownKey>,
+}
+
+/// Block-level keys that the parser injects or expects but that are not declared
+/// on any kind's struct (the `src` and `dest` tags are pulled out before parsing
+/// the inner variant).
+pub const STRUCTURAL_KEYS: &[&str] = &["src", "dest"];
+
+/// Field names allowed by the parsed source variant.
+pub fn source_known_fields(src: &LdrsSource) -> Vec<String> {
+    match src {
+        LdrsSource::File(_) => extract_props::<FileSource>(),
+        LdrsSource::SF(SFSource::Query(_)) => extract_props::<SFQuery>(),
+        LdrsSource::SF(SFSource::Table(_)) => extract_props::<SFTable>(),
+    }
+}
+
+/// Field names allowed by the parsed destination variant.
+pub fn destination_known_fields(dest: &LdrsDestination) -> Vec<String> {
+    match dest {
+        LdrsDestination::Pq(_) => extract_props::<ParquetDestination>(),
+        LdrsDestination::Pg(PgDestination::DropReplace(_)) => extract_props::<PgCommon>(),
+        LdrsDestination::Pg(PgDestination::TruncateInsert(_)) => extract_props::<PgCommon>(),
+        LdrsDestination::Pg(PgDestination::Merge(_)) => extract_props::<PgMerge>(),
+        LdrsDestination::Pg(PgDestination::DeleteInsert(_)) => extract_props::<PgDeleteInsert>(),
+        LdrsDestination::Delta(DeltaDestination::Overwrite(_)) => extract_props::<DeltaCommon>(),
+        LdrsDestination::Delta(DeltaDestination::Merge(_)) => extract_props::<DeltaMerge>(),
+        LdrsDestination::Arrow(_) => extract_props::<ArrowDestination>(),
+    }
+}
+
+/// Walks a raw block against the union of fields declared by the parsed src and
+/// dest variants, plus the block-level structural keys. Returns findings; does
+/// not emit. Caller decides when/how to surface them.
+pub fn find_unknown_block_keys(
+    value: &Value,
+    src: &LdrsSource,
+    dest: &LdrsDestination,
+) -> Vec<UnknownKey> {
+    let src_fields = source_known_fields(src);
+    let dest_fields = destination_known_fields(dest);
+    let allowed: HashSet<&str> = src_fields
+        .iter()
+        .map(String::as_str)
+        .chain(dest_fields.iter().map(String::as_str))
+        .chain(STRUCTURAL_KEYS.iter().copied())
+        .collect();
+    find_unknown_keys(value, &allowed)
 }
 
 pub fn merge_with_defaults(defaults: &Option<Value>, specific: Value) -> Value {
@@ -157,5 +212,68 @@ pub fn parse_dest(
         _ => Err(anyhow::Error::msg(
             "unsupported dest type (see `ldrs schema` for valid kinds)",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_known_fields_sf_query() {
+        let src = LdrsSource::SF(SFSource::Query(SFQuery {
+            sql: String::new(),
+            name: String::new(),
+            param_keys: None,
+        }));
+        let mut got = source_known_fields(&src);
+        got.sort();
+        assert_eq!(got, vec!["name", "param_keys", "sql"]);
+    }
+
+    #[test]
+    fn source_known_fields_file() {
+        let src = LdrsSource::File(FileSource {
+            name: String::new(),
+            filename: None,
+        });
+        let mut got = source_known_fields(&src);
+        got.sort();
+        assert_eq!(got, vec!["filename", "name"]);
+    }
+
+    #[test]
+    fn destination_known_fields_delta_merge_includes_flattened() {
+        let dest = LdrsDestination::Delta(DeltaDestination::Merge(DeltaMerge {
+            common: DeltaCommon {
+                name: String::new(),
+                columns: Vec::new(),
+                max_rows: None,
+                max_bytes: None,
+            },
+            merge_keys: Vec::new(),
+            allow_null_keys: false,
+            txn_mode: None,
+            watermark_column: None,
+            batch_version: None,
+            app_id: String::new(),
+        }));
+        let mut got = destination_known_fields(&dest);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "allow_null_keys",
+                "app_id",
+                "batch_version",
+                "columns",
+                "max_bytes",
+                "max_rows",
+                "merge_keys",
+                "name",
+                "txn_mode",
+                "watermark_column",
+            ]
+        );
     }
 }

--- a/crates/ldrs/src/ldrs_config/field_validation.rs
+++ b/crates/ldrs/src/ldrs_config/field_validation.rs
@@ -1,0 +1,216 @@
+use std::collections::HashSet;
+
+use schemars::{schema_for, JsonSchema};
+use serde_yaml::Value;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UnknownKey {
+    pub key: String,
+    pub suggestions: Vec<String>,
+}
+
+/// Walk a YAML Mapping's top-level keys and return any that aren't in `allowed`.
+/// Keys like `pq.filename` are stripped to their final segment before comparison;
+/// the original full key is preserved in `UnknownKey::key` for display.
+/// Non-Mapping inputs yield an empty vec.
+pub fn find_unknown_keys(value: &Value, allowed: &HashSet<&str>) -> Vec<UnknownKey> {
+    let Value::Mapping(map) = value else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (k, _) in map {
+        let Some(full) = k.as_str() else { continue };
+        let bare = full
+            .rsplit_once('.')
+            .map(|(_, suffix)| suffix)
+            .unwrap_or(full);
+        if allowed.contains(bare) {
+            continue;
+        }
+        let suggestions = close_matches(bare, allowed)
+            .into_iter()
+            .map(String::from)
+            .collect();
+        out.push(UnknownKey {
+            key: full.to_string(),
+            suggestions,
+        });
+    }
+    out
+}
+
+/// Top-level field names defined on `T` according to its schemars-derived schema.
+/// `#[serde(flatten)]` fields are surfaced inline in schemars 1.x output, so a
+pub fn extract_props<T: JsonSchema>() -> Vec<String> {
+    let schema = schema_for!(T);
+    let value = schema.to_value();
+    value
+        .as_object()
+        .and_then(|o| o.get("properties"))
+        .and_then(|p| p.as_object())
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// All candidates within Levenshtein distance 2 of `needle`, sorted by distance
+/// then lexicographically.
+fn close_matches<'a>(needle: &str, allowed: &HashSet<&'a str>) -> Vec<&'a str> {
+    let mut hits: Vec<(&'a str, usize)> = allowed
+        .iter()
+        .map(|c| (*c, levenshtein(needle, c)))
+        .filter(|(_, d)| *d <= 2)
+        .collect();
+    hits.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(b.0)));
+    hits.into_iter().map(|(c, _)| c).collect()
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (n, m) = (a.len(), b.len());
+    if n == 0 {
+        return m;
+    }
+    if m == 0 {
+        return n;
+    }
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr = vec![0usize; m + 1];
+    for i in 1..=n {
+        curr[0] = i;
+        for j in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (curr[j - 1] + 1).min(prev[j] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[m]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+    #[allow(dead_code)]
+    struct ExampleStruct {
+        foo: String,
+        bar: Option<i32>,
+        baz: Vec<String>,
+    }
+
+    #[test]
+    fn extract_props_returns_struct_fields() {
+        let mut got = extract_props::<ExampleStruct>();
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["bar".to_string(), "baz".to_string(), "foo".to_string()]
+        );
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("filename", "fileanme"), 2);
+        assert_eq!(levenshtein("merge_keys", "mergekeys"), 1);
+    }
+
+    #[test]
+    fn close_matches_returns_within_threshold_sorted() {
+        let allowed: HashSet<&str> = ["filename", "name", "columns"].into_iter().collect();
+        assert_eq!(close_matches("fileanme", &allowed), vec!["filename"]);
+        assert_eq!(close_matches("nme", &allowed), vec!["name"]);
+    }
+
+    #[test]
+    fn close_matches_far_miss_returns_empty() {
+        let allowed: HashSet<&str> = ["filename"].into_iter().collect();
+        assert_eq!(close_matches("xyzzy", &allowed), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn close_matches_empty_allowed_returns_empty() {
+        let allowed: HashSet<&str> = HashSet::new();
+        assert_eq!(close_matches("filename", &allowed), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn close_matches_multiple_candidates_sorted_by_distance_then_lex() {
+        // "abc" → distance 1 from "abcd" (insert) and "xbc" (substitute), distance 0 from "abc".
+        let allowed: HashSet<&str> = ["abcd", "xbc", "abc"].into_iter().collect();
+        assert_eq!(close_matches("abc", &allowed), vec!["abc", "abcd", "xbc"]);
+    }
+
+    #[test]
+    fn find_unknown_keys_non_mapping_is_empty() {
+        let allowed: HashSet<&str> = ["filename"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("- 1\n- 2").unwrap();
+        assert!(find_unknown_keys(&value, &allowed).is_empty());
+    }
+
+    #[test]
+    fn find_unknown_keys_known_key_passes() {
+        let allowed: HashSet<&str> = ["filename", "name"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("filename: x.parquet\nname: foo").unwrap();
+        assert!(find_unknown_keys(&value, &allowed).is_empty());
+    }
+
+    #[test]
+    fn find_unknown_keys_flags_with_suggestion() {
+        let allowed: HashSet<&str> = ["filename", "name"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("fileanme: y.parquet").unwrap();
+        assert_eq!(
+            find_unknown_keys(&value, &allowed),
+            vec![UnknownKey {
+                key: "fileanme".to_string(),
+                suggestions: vec!["filename".to_string()],
+            }],
+        );
+    }
+
+    #[test]
+    fn find_unknown_keys_flags_without_suggestion() {
+        let allowed: HashSet<&str> = ["filename"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("xyzzy: 1").unwrap();
+        assert_eq!(
+            find_unknown_keys(&value, &allowed),
+            vec![UnknownKey {
+                key: "xyzzy".to_string(),
+                suggestions: vec![],
+            }],
+        );
+    }
+
+    #[test]
+    fn find_unknown_keys_strips_prefix_before_check() {
+        let allowed: HashSet<&str> = ["filename"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("pq.filename: x").unwrap();
+        assert!(find_unknown_keys(&value, &allowed).is_empty());
+    }
+
+    #[test]
+    fn find_unknown_keys_strips_only_last_segment() {
+        let allowed: HashSet<&str> = ["merge_keys"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("delta.merge.merge_keys: [id]").unwrap();
+        assert!(find_unknown_keys(&value, &allowed).is_empty());
+    }
+
+    #[test]
+    fn find_unknown_keys_preserves_full_key_in_finding() {
+        let allowed: HashSet<&str> = ["filename"].into_iter().collect();
+        let value: Value = serde_yaml::from_str("pq.fileanme: x").unwrap();
+        assert_eq!(
+            find_unknown_keys(&value, &allowed),
+            vec![UnknownKey {
+                key: "pq.fileanme".to_string(),
+                suggestions: vec!["filename".to_string()],
+            }],
+        );
+    }
+}

--- a/crates/ldrs/src/ldrs_config/mod.rs
+++ b/crates/ldrs/src/ldrs_config/mod.rs
@@ -1,14 +1,19 @@
 pub mod config;
 
-use std::{pin::pin, sync::Arc};
+use std::{
+    io::{self, IsTerminal},
+    pin::pin,
+    sync::Arc,
+};
 
 use anyhow::Context;
+use arrow::ipc::writer::StreamWriter;
 use arrow_array::RecordBatch;
 use arrow_schema::{Schema, SchemaRef};
 use futures::Stream;
 use ldrs_arrow::{
-    build_arrow_transform_strategy, build_source_and_target_schema, ArrowColumnTransformStrategy,
-    ColumnSpec, ColumnType,
+    build_arrow_transform_strategy, build_source_and_target_schema, transform_batch,
+    ArrowColumnTransformStrategy, ColumnSpec, ColumnType,
 };
 use ldrs_delta::{merge_delta, overwrite_delta, MergeConfig, TxnConfig};
 use ldrs_parquet::{
@@ -19,14 +24,15 @@ use ldrs_postgres::check_for_role;
 use ldrs_storage::{base_or_relative_path, ensure_trailing_slash};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStream};
 use tokio::task::JoinHandle;
-use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tracing::{debug, info};
 use url::Url;
 
 use crate::{
-    delta::{DeltaMode, MergeTxnConfig},
+    delta::{DeltaDestination, DeltaMerge, MergeTxnConfig, TxnMode},
     ldrs_config::config::{
-        get_parsed_config, LdrsConfig, LdrsDestination, LdrsParsedConfig, LdrsSource,
+        merge_with_defaults, parse_dest, parse_src, LdrsConfig, LdrsDestination, LdrsParsedConfig,
+        LdrsSource,
     },
     ldrs_env::{collect_params, collect_vars_by_prefix, setup_handlebars, LdrsExecutionContext},
     ldrs_snowflake::{sf_arrow_stream, snowflake_source::SFSource, SnowflakeConnection},
@@ -59,6 +65,30 @@ struct LdrsSrcStream {
     stream_type: StreamType,
     source_cols: Vec<ColumnSpec>,
     cleanup_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
+}
+
+struct ExecutionEnv<'a> {
+    ldrs_env: &'a [(String, String)],
+    handlebars: handlebars::Handlebars<'a>,
+    handlebars_vars: Vec<(String, String)>,
+    typed_params: Vec<(String, String, Option<ColumnType>)>,
+}
+
+impl<'a> ExecutionEnv<'a> {
+    fn create(ldrs_env: &'a [(String, String)]) -> Self {
+        let env_params = collect_params(ldrs_env);
+        debug!("Environment Params: {:?}", env_params);
+        let mut handlebars = handlebars::Handlebars::new();
+        setup_handlebars(&mut handlebars);
+        let handlebars_vars = collect_vars_by_prefix(ldrs_env, "TEMPL");
+        debug!("Handlebars Vars: {:?}", handlebars_vars);
+        ExecutionEnv {
+            ldrs_env,
+            handlebars,
+            handlebars_vars,
+            typed_params: env_params,
+        }
+    }
 }
 
 pub fn get_env_value<'a>(
@@ -111,6 +141,7 @@ pub fn infer_env_type(env_type: &str, vars: &[(String, String)]) -> Option<Strin
     let url = src.and_then(|(_, value)| Url::parse(value).ok());
     match url {
         Some(u) => match u {
+            u if u.scheme().starts_with("snowflake") => Some("sf".to_string()),
             u if u.scheme().starts_with("delta+") => Some("delta".to_string()),
             u if is_object_store_url(&u) => Some("file".to_string()),
             u if u.scheme() == "postgres" => Some("pg".to_string()),
@@ -177,34 +208,38 @@ fn column_helper(
     Ok((target_cols, strategies))
 }
 
-pub async fn create_ldrs_exec(
+pub fn parse_yaml_config(
     config_string: &str,
     ldrs_env: &[(String, String)],
-    select: Option<Vec<String>>,
-    cloud_io_rt: &tokio::runtime::Handle,
-) -> Result<(), anyhow::Error> {
+) -> Result<Vec<LdrsParsedConfig>, anyhow::Error> {
     let config: LdrsConfig =
         serde_yaml::from_str(config_string).with_context(|| "Could not parse the config")?;
 
     let src_default = config.src.or(infer_env_type("LDRS_SRC", ldrs_env));
     let dest_default = config.dest.or(infer_env_type("LDRS_DEST", ldrs_env));
 
-    let table_tasks = config
+    config
         .tables
         .into_iter()
         .map(|t| {
-            get_parsed_config(
+            let src = parse_src(
+                merge_with_defaults(&config.src_defaults, t.clone()),
                 &src_default,
-                &dest_default,
-                &config.src_defaults,
-                &config.dest_defaults,
-                t,
-            )
+            )?;
+            let dest = parse_dest(merge_with_defaults(&config.dest_defaults, t), &dest_default)?;
+            Ok(LdrsParsedConfig { src, dest })
         })
-        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+        .collect::<Result<Vec<_>, anyhow::Error>>()
+}
 
+pub async fn execute_configs(
+    tasks: Vec<LdrsParsedConfig>,
+    select: Option<Vec<String>>,
+    ldrs_env: &[(String, String)],
+    cloud_io_rt: &tokio::runtime::Handle,
+) -> Result<(), anyhow::Error> {
     let filtered_tasks: Vec<_> = match select {
-        Some(selected_tables) => table_tasks
+        Some(selected_tables) => tasks
             .into_iter()
             .filter(|t| {
                 selected_tables
@@ -212,16 +247,11 @@ pub async fn create_ldrs_exec(
                     .any(|s| s.eq_ignore_ascii_case(t.src.name()))
             })
             .collect(),
-        None => table_tasks,
+        None => tasks,
     };
     debug!("Tasks to be run {:?}", filtered_tasks);
-    // get all possible environment params
-    let env_params = collect_params(ldrs_env);
-    debug!("Environment Params: {:?}", env_params);
-    let mut handlebars = handlebars::Handlebars::new();
-    setup_handlebars(&mut handlebars);
-    let handlebars_vars = collect_vars_by_prefix(ldrs_env, "TEMPL");
 
+    let exec_env = ExecutionEnv::create(ldrs_env);
     let total_tasks = filtered_tasks.len();
     for (i, task) in filtered_tasks.into_iter().enumerate() {
         let task_start = std::time::Instant::now();
@@ -229,10 +259,10 @@ pub async fn create_ldrs_exec(
         info!("Running task: {}/{}", i + 1, total_tasks);
         execute_task(
             task,
-            ldrs_env,
-            &handlebars,
-            &handlebars_vars,
-            &env_params,
+            exec_env.ldrs_env,
+            &exec_env.handlebars,
+            &exec_env.handlebars_vars,
+            &exec_env.typed_params,
             cloud_io_rt,
         )
         .await?;
@@ -378,14 +408,17 @@ pub async fn execute_task(
                 Ok(())
             }
             LdrsDestination::Delta(delta_dest) => {
-                let dest_value = get_dest_url(ldrs_env, &delta_dest.name, "delta")?;
+                let (name, columns) = match &delta_dest {
+                    DeltaDestination::Overwrite(c) => (c.name.clone(), c.columns.clone()),
+                    DeltaDestination::Merge(m) => (m.common.name.clone(), m.common.columns.clone()),
+                };
+
+                let dest_value = get_dest_url(ldrs_env, &name, "delta")?;
                 let storage_url = dest_value.1.strip_prefix("delta+").unwrap_or(&dest_value.1);
                 let storage_url = ensure_trailing_slash(storage_url);
-                let table_path =
-                    ensure_trailing_slash(&format!("{}{}", storage_url, delta_dest.name));
+                let table_path = ensure_trailing_slash(&format!("{}{}", storage_url, name));
                 debug!("delta path: {:?}", table_path);
-                let (target_cols, strategies) =
-                    column_helper(src.source_cols, delta_dest.columns, &schema)?;
+                let (target_cols, strategies) = column_helper(src.source_cols, columns, &schema)?;
 
                 debug!("Target columns: {:?}", target_cols);
                 debug!("Arrow Transforms: {:?}", strategies);
@@ -399,29 +432,49 @@ pub async fn execute_task(
                     schema
                 };
 
-                match delta_dest.mode {
-                    DeltaMode::Overwrite => {
+                match delta_dest {
+                    DeltaDestination::Overwrite(o) => {
                         overwrite_delta(
                             &table_path,
                             schema,
                             strategies,
                             src.stream_type,
-                            delta_dest.max_rows,
-                            delta_dest.max_bytes,
+                            o.max_rows,
+                            o.max_bytes,
                         )
                         .await?;
                     }
-                    DeltaMode::Merge {
-                        merge_keys,
-                        allow_null_keys,
-                        txn,
-                    } => {
+                    DeltaDestination::Merge(m) => {
+                        let DeltaMerge {
+                            merge_keys,
+                            allow_null_keys,
+                            txn_mode,
+                            watermark_column,
+                            batch_version,
+                            app_id,
+                            ..
+                        } = m;
+                        let txn = match txn_mode {
+                            None => None,
+                            Some(TxnMode::SourceWatermark) => {
+                                Some(MergeTxnConfig::SourceWatermark {
+                                    app_id,
+                                    watermark_column: watermark_column.expect(
+                                        "validate ensures watermark_column for source_watermark",
+                                    ),
+                                })
+                            }
+                            Some(TxnMode::ProcessingTime) => Some(MergeTxnConfig::ProcessingTime {
+                                app_id,
+                                batch_version,
+                            }),
+                        };
                         let txn_config = resolve_txn_config(txn, &context)?;
                         let merge_config = MergeConfig {
                             merge_keys,
                             allow_null_keys,
-                            max_rows: delta_dest.max_rows,
-                            max_bytes: delta_dest.max_bytes,
+                            max_rows: m.common.max_rows,
+                            max_bytes: m.common.max_bytes,
                             txn_config,
                         };
                         merge_delta(
@@ -434,6 +487,38 @@ pub async fn execute_task(
                         .await?;
                     }
                 }
+                Ok(())
+            }
+            LdrsDestination::Arrow(arrow_dest) => {
+                let (target_cols, strategies) =
+                    column_helper(src.source_cols, arrow_dest.columns, &schema)?;
+                debug!("Target columns: {:?}", target_cols);
+                debug!("Arrow Transforms: {:?}", strategies);
+                if io::stdout().is_terminal() {
+                    return Err(anyhow::Error::msg("Outputting Arrow IPC Stream to stdout is not supported in a terminal. Please redirect the output to a file or pipe it to another command."));
+                }
+                let stdout = io::stdout().lock();
+                let schema = if strategies.iter().any(|s| s.is_some()) {
+                    let fields = target_cols
+                        .iter()
+                        .map(|c| c.to_arrow_field())
+                        .collect::<Vec<_>>();
+                    Arc::new(Schema::new(fields))
+                } else {
+                    schema
+                };
+                let mut writer = StreamWriter::try_new_buffered(stdout, &schema)?;
+                let mut pinned = pin!(src.stream_type);
+                while let Some(batch) = pinned.next().await {
+                    let batch = batch?;
+                    let transformed_batch = if strategies.iter().any(|s| s.is_some()) {
+                        transform_batch(&batch, &strategies, schema.clone())?
+                    } else {
+                        batch
+                    };
+                    writer.write(&transformed_batch)?;
+                }
+                writer.finish()?;
                 Ok(())
             }
         },

--- a/crates/ldrs/src/ldrs_config/mod.rs
+++ b/crates/ldrs/src/ldrs_config/mod.rs
@@ -8,7 +8,7 @@ use arrow_schema::{Schema, SchemaRef};
 use futures::Stream;
 use ldrs_arrow::{
     build_arrow_transform_strategy, build_source_and_target_schema, ArrowColumnTransformStrategy,
-    ColumnSpec,
+    ColumnSpec, ColumnType,
 };
 use ldrs_delta::{merge_delta, overwrite_delta, MergeConfig, TxnConfig};
 use ldrs_parquet::{
@@ -25,7 +25,9 @@ use url::Url;
 
 use crate::{
     delta::{DeltaMode, MergeTxnConfig},
-    ldrs_config::config::{get_parsed_config, LdrsConfig, LdrsDestination, LdrsSource},
+    ldrs_config::config::{
+        get_parsed_config, LdrsConfig, LdrsDestination, LdrsParsedConfig, LdrsSource,
+    },
     ldrs_env::{collect_params, collect_vars_by_prefix, setup_handlebars, LdrsExecutionContext},
     ldrs_snowflake::{sf_arrow_stream, snowflake_source::SFSource, SnowflakeConnection},
     postgres::execute::load_to_postgres,
@@ -225,215 +227,229 @@ pub async fn create_ldrs_exec(
         let task_start = std::time::Instant::now();
         debug!("Task: {:?}", task);
         info!("Running task: {}/{}", i + 1, total_tasks);
-        let (src, context) = match task.src {
-            LdrsSource::File(file) => {
-                let ldrs_context =
-                    LdrsExecutionContext::try_new(&file.name, &handlebars, &handlebars_vars)?;
-                // if the filename is not provided, use the name as the filename
-                let file_name = file.filename.as_deref().unwrap_or(file.name.as_str());
-                let src_value = get_src_url(ldrs_env, &file.name, "file")?;
-                // render the filename if it has tokens in the path
-                let joined = ldrs_context.render_template(&format!(
-                    "{}{}",
-                    src_value.1.as_str(),
-                    file_name
-                ))?;
-                let src_url = base_or_relative_path(&joined)?;
-                let builder = builder_from_url(src_url.clone(), cloud_io_rt.clone()).await?;
-
-                let schema = builder.schema().clone();
-
-                let file_md = builder.metadata().clone();
-                let fields = get_fields(file_md.file_metadata())?;
-
-                // matches DuckDB STANDARD_VECTOR_SIZE
-                let stream = builder.with_batch_size(2048).build()?;
-                let source_cols = fields
-                    .iter()
-                    .filter_map(|pq| columnspec_from_parquet(pq).ok())
-                    .collect::<Vec<_>>();
-                (
-                    LdrsSrcStream {
-                        schema: Some(schema),
-                        stream_type: StreamType::Parquet(stream),
-                        source_cols,
-                        cleanup_handle: None,
-                    },
-                    ldrs_context,
-                )
-            }
-            LdrsSource::SF(sf) => {
-                let sf_sql = match &sf {
-                    SFSource::Query(sql) => sql.sql.clone(),
-                    SFSource::Table(table) => format!("SELECT * FROM {}", table.name),
-                };
-                let name = sf.get_name();
-                let sf_src = get_src_url(ldrs_env, &name, "sf")?;
-                let ldrs_context =
-                    LdrsExecutionContext::try_new(&name, &handlebars, &handlebars_vars)?;
-                let handled_name = ldrs_context.render_template("{{ shoutySnakeCase name }}")?;
-                let sf_params = sf.try_get_env_params(&handled_name, &env_params)?;
-                debug!("Snowflake Params: {:?}", sf_params);
-                let rendered_sql = ldrs_context.render_template(&sf_sql)?;
-                let conn = SnowflakeConnection::create_connection(&sf_src.1)?;
-                let arrow_stream = sf_arrow_stream(&conn, &rendered_sql, sf_params).await?;
-                let schema = arrow_stream.schema_stream.await;
-                (
-                    LdrsSrcStream {
-                        schema,
-                        stream_type: StreamType::Receiver(arrow_stream.batch_stream),
-                        source_cols: vec![],
-                        cleanup_handle: Some(arrow_stream.command_handle),
-                    },
-                    ldrs_context,
-                )
-            }
-        };
-
-        let _ = match src.schema {
-            Some(schema) => match task.dest {
-                LdrsDestination::Pg(pg_dest) => {
-                    let dest_value = get_dest_url(ldrs_env, pg_dest.get_name(), "pg")?;
-                    let (pg_url, role) = check_for_role(dest_value.1.as_str())?;
-                    // check the environment for a pg role
-                    let role = role.or(get_env_value(
-                        ldrs_env,
-                        &[
-                            &format!("LDRS_PG_ROLE_{}", pg_dest.get_name()),
-                            "LDRS_PG_ROLE",
-                        ],
-                    )
-                    .map(|(_, v)| v.to_string()));
-                    let pg_commands = pg_dest.to_pg_commands();
-                    let (target_cols, strategies) =
-                        column_helper(src.source_cols, pg_dest.get_columns(), &schema)?;
-                    info!("Target columns: {:?}", target_cols);
-                    info!("Arrow Transforms: {:?}", strategies);
-                    // collect the params that can be bound
-                    let env_params = collect_params(ldrs_env);
-                    load_to_postgres(
-                        &pg_url,
-                        &pg_commands,
-                        &target_cols,
-                        &strategies,
-                        &env_params,
-                        role,
-                        &context,
-                        src.stream_type,
-                    )
-                    .await
-                }
-                LdrsDestination::Pq(parq) => {
-                    let dest_value = get_dest_url(ldrs_env, &parq.name, "pq")?;
-                    let dest_value = ensure_trailing_slash(dest_value.1.as_str());
-                    let handled_filename = context.render_template(&parq.filename)?;
-                    let full_path = format!("{}{}", dest_value, handled_filename);
-                    let full_name = base_or_relative_path(&full_path)?;
-                    debug!("full_name: {:?}", full_name);
-                    let (target_cols, strategies) =
-                        column_helper(src.source_cols, parq.columns, &schema)?;
-
-                    info!("Target columns: {:?}", target_cols);
-                    info!("Arrow Transforms: {:?}", strategies);
-                    // create the new schema if there are any type changes
-                    // adding and keeping the current metadata
-                    let schema = if strategies.iter().any(|s| s.is_some()) {
-                        let fields = target_cols
-                            .iter()
-                            .map(|col| col.to_arrow_field())
-                            .collect::<Vec<_>>();
-                        Arc::new(Schema::new(fields))
-                    } else {
-                        schema
-                    };
-                    let props = with_bloom_filters(default_writer_props(), parq.bloom_filters);
-                    let _ = write_parquet(
-                        &full_name.to_string(),
-                        schema,
-                        strategies,
-                        Some(props),
-                        src.stream_type,
-                    )
-                    .await?;
-                    Ok(())
-                }
-                LdrsDestination::Delta(delta_dest) => {
-                    let dest_value = get_dest_url(ldrs_env, &delta_dest.name, "delta")?;
-                    let storage_url = dest_value.1.strip_prefix("delta+").unwrap_or(&dest_value.1);
-                    let storage_url = ensure_trailing_slash(storage_url);
-                    let table_path =
-                        ensure_trailing_slash(&format!("{}{}", storage_url, delta_dest.name));
-                    debug!("delta path: {:?}", table_path);
-                    let (target_cols, strategies) =
-                        column_helper(src.source_cols, delta_dest.columns, &schema)?;
-
-                    info!("Target columns: {:?}", target_cols);
-                    info!("Arrow Transforms: {:?}", strategies);
-                    let schema = if strategies.iter().any(|s| s.is_some()) {
-                        let fields = target_cols
-                            .iter()
-                            .map(|col| col.to_arrow_field())
-                            .collect::<Vec<_>>();
-                        Arc::new(Schema::new(fields))
-                    } else {
-                        schema
-                    };
-
-                    match delta_dest.mode {
-                        DeltaMode::Overwrite => {
-                            overwrite_delta(
-                                &table_path,
-                                schema,
-                                strategies,
-                                src.stream_type,
-                                delta_dest.max_rows,
-                                delta_dest.max_bytes,
-                            )
-                            .await?;
-                        }
-                        DeltaMode::Merge {
-                            merge_keys,
-                            allow_null_keys,
-                            txn,
-                        } => {
-                            let txn_config = resolve_txn_config(txn, &context)?;
-                            let merge_config = MergeConfig {
-                                merge_keys,
-                                allow_null_keys,
-                                max_rows: delta_dest.max_rows,
-                                max_bytes: delta_dest.max_bytes,
-                                txn_config,
-                            };
-                            merge_delta(
-                                &table_path,
-                                schema,
-                                strategies,
-                                src.stream_type,
-                                merge_config,
-                            )
-                            .await?;
-                        }
-                    }
-                    Ok(())
-                }
-            },
-            None => {
-                info!("No schema found, most likely the load failed or no Arrow Record Batches were produced.");
-                Ok(())
-            }
-        }?;
-
-        if let Some(handle) = src.cleanup_handle {
-            match handle.await {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(e)) => Err(e),
-                Err(e) => Err(anyhow::anyhow!("ldrs-sf task panicked: {}", e)),
-            }?
-        }
+        execute_task(
+            task,
+            ldrs_env,
+            &handlebars,
+            &handlebars_vars,
+            &env_params,
+            cloud_io_rt,
+        )
+        .await?;
         let task_end = std::time::Instant::now();
         info!("Task time: {:?}", task_end - task_start);
     }
 
+    Ok(())
+}
+
+pub async fn execute_task(
+    task: LdrsParsedConfig,
+    ldrs_env: &[(String, String)],
+    handlebars: &handlebars::Handlebars<'_>,
+    handlebars_vars: &[(String, String)],
+    env_params: &[(String, String, Option<ColumnType>)],
+    cloud_io_rt: &tokio::runtime::Handle,
+) -> Result<(), anyhow::Error> {
+    let (src, context) = match task.src {
+        LdrsSource::File(file) => {
+            let ldrs_context =
+                LdrsExecutionContext::try_new(&file.name, &handlebars, &handlebars_vars)?;
+            // if the filename is not provided, use the name as the filename
+            let file_name = file.filename.as_deref().unwrap_or(file.name.as_str());
+            let src_value = get_src_url(ldrs_env, &file.name, "file")?;
+            // render the filename if it has tokens in the path
+            let joined =
+                ldrs_context.render_template(&format!("{}{}", src_value.1.as_str(), file_name))?;
+            let src_url = base_or_relative_path(&joined)?;
+            let builder = builder_from_url(src_url.clone(), cloud_io_rt.clone()).await?;
+
+            let schema = builder.schema().clone();
+
+            let file_md = builder.metadata().clone();
+            let fields = get_fields(file_md.file_metadata())?;
+
+            // matches DuckDB STANDARD_VECTOR_SIZE
+            let stream = builder.with_batch_size(2048).build()?;
+            let source_cols = fields
+                .iter()
+                .filter_map(|pq| columnspec_from_parquet(pq).ok())
+                .collect::<Vec<_>>();
+            (
+                LdrsSrcStream {
+                    schema: Some(schema),
+                    stream_type: StreamType::Parquet(stream),
+                    source_cols,
+                    cleanup_handle: None,
+                },
+                ldrs_context,
+            )
+        }
+        LdrsSource::SF(sf) => {
+            let sf_sql = match &sf {
+                SFSource::Query(sql) => sql.sql.clone(),
+                SFSource::Table(table) => format!("SELECT * FROM {}", table.name),
+            };
+            let name = sf.get_name();
+            let sf_src = get_src_url(ldrs_env, &name, "sf")?;
+            let ldrs_context = LdrsExecutionContext::try_new(&name, &handlebars, &handlebars_vars)?;
+            let handled_name = ldrs_context.render_template("{{ shoutySnakeCase name }}")?;
+            let sf_params = sf.try_get_env_params(&handled_name, &env_params)?;
+            debug!("Snowflake Params: {:?}", sf_params);
+            let rendered_sql = ldrs_context.render_template(&sf_sql)?;
+            let conn = SnowflakeConnection::create_connection(&sf_src.1)?;
+            let arrow_stream = sf_arrow_stream(&conn, &rendered_sql, sf_params).await?;
+            let schema = arrow_stream.schema_stream.await;
+            (
+                LdrsSrcStream {
+                    schema,
+                    stream_type: StreamType::Receiver(arrow_stream.batch_stream),
+                    source_cols: vec![],
+                    cleanup_handle: Some(arrow_stream.command_handle),
+                },
+                ldrs_context,
+            )
+        }
+    };
+
+    let _ = match src.schema {
+        Some(schema) => match task.dest {
+            LdrsDestination::Pg(pg_dest) => {
+                let dest_value = get_dest_url(ldrs_env, pg_dest.get_name(), "pg")?;
+                let (pg_url, role) = check_for_role(dest_value.1.as_str())?;
+                // check the environment for a pg role
+                let role = role.or(get_env_value(
+                    ldrs_env,
+                    &[
+                        &format!("LDRS_PG_ROLE_{}", pg_dest.get_name()),
+                        "LDRS_PG_ROLE",
+                    ],
+                )
+                .map(|(_, v)| v.to_string()));
+                let pg_commands = pg_dest.to_pg_commands();
+                let (target_cols, strategies) =
+                    column_helper(src.source_cols, pg_dest.get_columns(), &schema)?;
+                debug!("Target columns: {:?}", target_cols);
+                debug!("Arrow Transforms: {:?}", strategies);
+                load_to_postgres(
+                    &pg_url,
+                    &pg_commands,
+                    &target_cols,
+                    &strategies,
+                    &env_params,
+                    role,
+                    &context,
+                    src.stream_type,
+                )
+                .await
+            }
+            LdrsDestination::Pq(parq) => {
+                let dest_value = get_dest_url(ldrs_env, &parq.name, "pq")?;
+                let dest_value = ensure_trailing_slash(dest_value.1.as_str());
+                let handled_filename = context.render_template(&parq.filename)?;
+                let full_path = format!("{}{}", dest_value, handled_filename);
+                let full_name = base_or_relative_path(&full_path)?;
+                debug!("full_name: {:?}", full_name);
+                let (target_cols, strategies) =
+                    column_helper(src.source_cols, parq.columns, &schema)?;
+
+                debug!("Target columns: {:?}", target_cols);
+                debug!("Arrow Transforms: {:?}", strategies);
+                // create the new schema if there are any type changes
+                // adding and keeping the current metadata
+                let schema = if strategies.iter().any(|s| s.is_some()) {
+                    let fields = target_cols
+                        .iter()
+                        .map(|col| col.to_arrow_field())
+                        .collect::<Vec<_>>();
+                    Arc::new(Schema::new(fields))
+                } else {
+                    schema
+                };
+                let props = with_bloom_filters(default_writer_props(), parq.bloom_filters);
+                let _ = write_parquet(
+                    &full_name.to_string(),
+                    schema,
+                    strategies,
+                    Some(props),
+                    src.stream_type,
+                )
+                .await?;
+                Ok(())
+            }
+            LdrsDestination::Delta(delta_dest) => {
+                let dest_value = get_dest_url(ldrs_env, &delta_dest.name, "delta")?;
+                let storage_url = dest_value.1.strip_prefix("delta+").unwrap_or(&dest_value.1);
+                let storage_url = ensure_trailing_slash(storage_url);
+                let table_path =
+                    ensure_trailing_slash(&format!("{}{}", storage_url, delta_dest.name));
+                debug!("delta path: {:?}", table_path);
+                let (target_cols, strategies) =
+                    column_helper(src.source_cols, delta_dest.columns, &schema)?;
+
+                debug!("Target columns: {:?}", target_cols);
+                debug!("Arrow Transforms: {:?}", strategies);
+                let schema = if strategies.iter().any(|s| s.is_some()) {
+                    let fields = target_cols
+                        .iter()
+                        .map(|col| col.to_arrow_field())
+                        .collect::<Vec<_>>();
+                    Arc::new(Schema::new(fields))
+                } else {
+                    schema
+                };
+
+                match delta_dest.mode {
+                    DeltaMode::Overwrite => {
+                        overwrite_delta(
+                            &table_path,
+                            schema,
+                            strategies,
+                            src.stream_type,
+                            delta_dest.max_rows,
+                            delta_dest.max_bytes,
+                        )
+                        .await?;
+                    }
+                    DeltaMode::Merge {
+                        merge_keys,
+                        allow_null_keys,
+                        txn,
+                    } => {
+                        let txn_config = resolve_txn_config(txn, &context)?;
+                        let merge_config = MergeConfig {
+                            merge_keys,
+                            allow_null_keys,
+                            max_rows: delta_dest.max_rows,
+                            max_bytes: delta_dest.max_bytes,
+                            txn_config,
+                        };
+                        merge_delta(
+                            &table_path,
+                            schema,
+                            strategies,
+                            src.stream_type,
+                            merge_config,
+                        )
+                        .await?;
+                    }
+                }
+                Ok(())
+            }
+        },
+        None => {
+            info!("No schema found, most likely the load failed or no Arrow Record Batches were produced.");
+            Ok(())
+        }
+    }?;
+
+    if let Some(handle) = src.cleanup_handle {
+        match handle.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(anyhow::anyhow!("ldrs-sf task panicked: {}", e)),
+        }?
+    }
     Ok(())
 }
 

--- a/crates/ldrs/src/ldrs_config/mod.rs
+++ b/crates/ldrs/src/ldrs_config/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod field_validation;
 
 use std::{
     io::{self, IsTerminal},
@@ -25,7 +26,7 @@ use ldrs_storage::{base_or_relative_path, ensure_trailing_slash};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStream};
 use tokio::task::JoinHandle;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::{
@@ -222,12 +223,19 @@ pub fn parse_yaml_config(
         .tables
         .into_iter()
         .map(|t| {
+            let raw_block = t.clone();
             let src = parse_src(
                 merge_with_defaults(&config.src_defaults, t.clone()),
                 &src_default,
             )?;
             let dest = parse_dest(merge_with_defaults(&config.dest_defaults, t), &dest_default)?;
-            Ok(LdrsParsedConfig { src, dest })
+            let unknown_keys =
+                crate::ldrs_config::config::find_unknown_block_keys(&raw_block, &src, &dest);
+            Ok(LdrsParsedConfig {
+                src,
+                dest,
+                unknown_keys,
+            })
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()
 }
@@ -256,6 +264,30 @@ pub async fn execute_configs(
     for (i, task) in filtered_tasks.into_iter().enumerate() {
         let task_start = std::time::Instant::now();
         debug!("Task: {:?}", task);
+        let task_name = task.src.name();
+        for u in &task.unknown_keys {
+            match u.suggestions.as_slice() {
+                [] => warn!(
+                    "table '{}': '{}' is not a known field (see `ldrs schema`)",
+                    task_name, u.key
+                ),
+                [one] => warn!(
+                    "table '{}': '{}' is not a known field (did you mean '{}'? see `ldrs schema`)",
+                    task_name, u.key, one
+                ),
+                many => {
+                    let joined = many
+                        .iter()
+                        .map(|s| format!("'{}'", s))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    warn!(
+                        "table '{}': '{}' is not a known field (did you mean one of {}? see `ldrs schema`)",
+                        task_name, u.key, joined
+                    );
+                }
+            }
+        }
         info!("Running task: {}/{}", i + 1, total_tasks);
         execute_task(
             task,

--- a/crates/ldrs/src/ldrs_snowflake/snowflake_source.rs
+++ b/crates/ldrs/src/ldrs_snowflake/snowflake_source.rs
@@ -10,6 +10,9 @@ pub struct SFQuery {
     pub sql: String,
     pub name: String,
     #[serde(default)]
+    #[schemars(
+        description = "Names of the `LDRS_PARAM_<NAME>` env vars to bind into `sql`. Each entry names a distinct env var. Binding is positional in lexicographic order of the env-var names — array order in this field is ignored. Snowflake's driver uses `?` as the placeholder; this is part of the binding contract, not ldrs's surface. Optional per-position type coercion via the `LDRS_PARAM_<NAME>_<TYPE>` env-var suffix."
+    )]
     pub param_keys: Option<Vec<String>>,
 }
 

--- a/crates/ldrs/src/ldrs_snowflake/snowflake_source.rs
+++ b/crates/ldrs/src/ldrs_snowflake/snowflake_source.rs
@@ -1,10 +1,11 @@
 use ldrs_arrow::ColumnType;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 use crate::ldrs_env::{get_env_values_by_keys, get_params_for_stmt_with_default};
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SFQuery {
     pub sql: String,
     pub name: String,
@@ -12,13 +13,16 @@ pub struct SFQuery {
     pub param_keys: Option<Vec<String>>,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SFTable {
     pub name: String,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "src")]
+#[schemars(
+    description = "Snowflake source. Reads via the LDRS_SRC connection URL; sf.query executes a SQL statement, sf.table reads a named table."
+)]
 pub enum SFSource {
     #[serde(rename = "sf.query")]
     Query(SFQuery),
@@ -103,7 +107,9 @@ pub fn from_serde_yaml(yaml: &Value, tag: Option<&str>) -> Result<SFSource, anyh
                 Some(_) => Err(anyhow::Error::msg("Invalid tag")),
             }
         }
-        (None, _) => Err(anyhow::Error::msg("Missing 'name' key")),
+        (None, _) => Err(anyhow::Error::msg(
+            "Missing name for kind sf (see `ldrs schema sf` for required fields)",
+        )),
     }
 }
 

--- a/crates/ldrs/src/lib.rs
+++ b/crates/ldrs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cli_schema;
 pub mod delta;
 pub mod file_source;
 pub mod ldrs_config;

--- a/crates/ldrs/src/main.rs
+++ b/crates/ldrs/src/main.rs
@@ -1,16 +1,20 @@
-use std::fs;
+use std::{fs, io};
 
 use anyhow::Context;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use dotenvy::dotenv;
-use ldrs::ldrs_config::create_ldrs_exec;
+use ldrs::cli_schema;
+use ldrs::ldrs_config::config::{parse_dest, parse_src, LdrsParsedConfig};
+use ldrs::ldrs_config::{execute_configs, infer_env_type, parse_yaml_config};
 use ldrs::ldrs_env::get_all_ldrs_env_vars;
 use ldrs::lua_logic::lua_args::{modules_from_args, LuaArgs, SnowflakeResult, SnowflakeStrategy};
 use ldrs::lua_logic::{LuaFunctionLoader, StorageData, UrlData};
 use ldrs::path_pattern;
 use ldrs_storage::build_store;
 use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
 use tracing::info;
+use tracing_subscriber::fmt;
 
 // maintaining this so clients do not break
 #[derive(Args, Deserialize, Debug)]
@@ -53,6 +57,43 @@ pub enum SnowflakeCommands {
     },
 }
 
+#[derive(Args)]
+#[command(
+    after_help = "Tip: run `ldrs schema` to discover valid --src/--dest kinds, their required fields, and supported --opt keys. Use `ldrs schema <kind>` (e.g. `ldrs schema pq`) for a single kind."
+)]
+struct RunArgs {
+    /// Base config blob (YAML or JSON). A single table block.
+    /// All other config args will override values in this.
+    #[arg(long)]
+    config_inline: Option<String>,
+
+    /// Source kind (file, sf, etc). Optional: can be inferred from LDRS_SRC
+    #[arg(long)]
+    src: Option<String>,
+
+    /// Destination kind (pg.merge, pq, delta.overwrite, etc). Optional: can be inferred from LDRS_DEST
+    #[arg(long)]
+    dest: Option<String>,
+
+    /// Table identifier.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// SQL for query-shaped sources. Shortcut for --opt sql=
+    #[arg(long)]
+    sql: Option<String>,
+
+    /// Per-kind options as key=value. Keys may be namespaced (pg.merge_keys, file.partition_cols).
+    #[arg(long = "opt", value_parser = parse_kv)]
+    opt: Vec<(String, String)>,
+}
+
+#[derive(Args)]
+struct SchemaArgs {
+    /// Optional kind name (file, sf, pg, pq, delta, arrow). If omitted, the full dump is emitted.
+    kind: Option<String>,
+}
+
 #[derive(Subcommand)]
 enum Destination {
     /// Load from a config file. All sources and destinations
@@ -67,9 +108,49 @@ enum Destination {
         #[command(subcommand)]
         command: SnowflakeCommands,
     },
+    /// Singular load from inline config and/or cli args
+    Run(RunArgs),
+    /// Discover available sources, destinations, and config options. Start here for one-off runs.
+    Schema(SchemaArgs),
 }
 
-const BANNER: &str = r#" ████      █████
+fn parse_kv(s: &str) -> Result<(String, String), String> {
+    s.split_once('=')
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .ok_or_else(|| format!("expected KEY=VALUE, got `{}`", s))
+        .and_then(|(k, v)| {
+            if k.is_empty() {
+                Err(format!("key cannot be empty in `{}`", s))
+            } else {
+                Ok((k, v))
+            }
+        })
+}
+
+fn build_run_block(args: &RunArgs) -> Result<Value, anyhow::Error> {
+    let mut block: Mapping = match args.config_inline.as_deref() {
+        Some(s) => serde_yaml::from_str::<Mapping>(s)?,
+        None => Mapping::new(),
+    };
+    for (k, v) in &args.opt {
+        block.insert(Value::String(k.clone()), Value::String(v.clone()));
+    }
+    for (k, v) in [
+        ("src", args.src.as_ref()),
+        ("dest", args.dest.as_ref()),
+        ("name", args.name.as_ref()),
+        ("sql", args.sql.as_ref()),
+    ] {
+        if let Some(v) = v {
+            block.insert(Value::String(k.to_string()), Value::String(v.clone()));
+        }
+    }
+    Ok(Value::Mapping(block))
+}
+
+const BANNER: &str = r#"
+
+ ████      █████
 ░░███     ░░███
  ░███   ███████  ████████   █████
  ░███  ███░░███ ░░███░░███ ███░░
@@ -87,7 +168,7 @@ struct Cli {
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    tracing_subscriber::fmt::init();
+    fmt::Subscriber::builder().with_writer(io::stderr).init();
     let cli = Cli::parse();
     let _ = dotenv();
 
@@ -97,6 +178,7 @@ fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     };
 
+    let is_data_command = !matches!(destination, Destination::Schema(_));
     let start = std::time::Instant::now();
 
     let main_rt = tokio::runtime::Builder::new_multi_thread()
@@ -119,7 +201,8 @@ fn main() -> Result<(), anyhow::Error> {
                 let config_string = fs::read_to_string(&args.config)
                     .with_context(|| format!("Failed to read config file: {}", args.config))?;
                 let ldrs_env = get_all_ldrs_env_vars();
-                create_ldrs_exec(&config_string, &ldrs_env, args.select, &rt.handle()).await
+                let configs = parse_yaml_config(&config_string, &ldrs_env)?;
+                execute_configs(configs, args.select, &ldrs_env, &rt.handle()).await
             }
             Destination::Delta { command } => match command {
                 DeltaCommands::Load(args) => {
@@ -127,6 +210,29 @@ fn main() -> Result<(), anyhow::Error> {
                     Ok(())
                 }
             },
+            Destination::Run(args) => {
+                let ldrs_env = get_all_ldrs_env_vars();
+                let config = build_run_block(&args)?;
+                let src_default = infer_env_type("LDRS_SRC", &ldrs_env);
+                let dest_default = infer_env_type("LDRS_DEST", &ldrs_env);
+                let src = parse_src(config.clone(), &src_default)?;
+                let dest = parse_dest(config, &dest_default)?;
+                execute_configs(
+                    vec![LdrsParsedConfig { src, dest }],
+                    None,
+                    &ldrs_env,
+                    &rt.handle(),
+                )
+                .await
+            }
+            Destination::Schema(args) => {
+                let output = match args.kind.as_deref() {
+                    None => cli_schema::build_full(),
+                    Some(kind) => cli_schema::build_one(kind)?,
+                };
+                println!("{}", serde_json::to_string_pretty(&output)?);
+                Ok(())
+            }
             Destination::Sf { command } => match command {
                 SnowflakeCommands::Exec { sql } => {
                     match std::env::var("LDRS_URL").with_context(|| "LDRS_URL not set") {
@@ -203,6 +309,119 @@ fn main() -> Result<(), anyhow::Error> {
     drop(rt);
 
     let end = std::time::Instant::now();
-    info!("Time to load: {:?}", end - start);
+    if is_data_command {
+        info!("Time to load: {:?}", end - start);
+    }
     command_exec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_args() -> RunArgs {
+        RunArgs {
+            config_inline: None,
+            src: None,
+            dest: None,
+            name: None,
+            sql: None,
+            opt: vec![],
+        }
+    }
+
+    fn get_str<'a>(v: &'a Value, key: &str) -> Option<&'a str> {
+        v.get(key).and_then(|x| x.as_str())
+    }
+
+    #[test]
+    fn parse_kv_simple() {
+        assert_eq!(parse_kv("k=v").unwrap(), ("k".to_string(), "v".to_string()));
+    }
+
+    #[test]
+    fn parse_kv_empty_key_rejected() {
+        assert!(parse_kv("=v").is_err());
+    }
+
+    #[test]
+    fn parse_kv_no_equals_rejected() {
+        assert!(parse_kv("kv").is_err());
+    }
+
+    #[test]
+    fn parse_kv_splits_on_first_equals() {
+        assert_eq!(
+            parse_kv("k=v=v2").unwrap(),
+            ("k".to_string(), "v=v2".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_kv_empty_value_allowed() {
+        assert_eq!(parse_kv("k=").unwrap(), ("k".to_string(), "".to_string()));
+    }
+
+    #[test]
+    fn build_run_block_inline_only() {
+        let args = RunArgs {
+            config_inline: Some("src: file".to_string()),
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "src"), Some("file"));
+    }
+
+    #[test]
+    fn build_run_block_flag_only() {
+        let args = RunArgs {
+            src: Some("sf".to_string()),
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "src"), Some("sf"));
+    }
+
+    #[test]
+    fn build_run_block_opt_only() {
+        let args = RunArgs {
+            opt: vec![("merge_keys".to_string(), "id".to_string())],
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "merge_keys"), Some("id"));
+    }
+
+    #[test]
+    fn build_run_block_flag_beats_inline() {
+        let args = RunArgs {
+            config_inline: Some("src: file".to_string()),
+            src: Some("sf".to_string()),
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "src"), Some("sf"));
+    }
+
+    #[test]
+    fn build_run_block_opt_beats_inline() {
+        let args = RunArgs {
+            config_inline: Some("src: file".to_string()),
+            opt: vec![("src".to_string(), "sf".to_string())],
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "src"), Some("sf"));
+    }
+
+    #[test]
+    fn build_run_block_flag_beats_opt() {
+        let args = RunArgs {
+            opt: vec![("src".to_string(), "file".to_string())],
+            src: Some("sf".to_string()),
+            ..empty_args()
+        };
+        let v = build_run_block(&args).unwrap();
+        assert_eq!(get_str(&v, "src"), Some("sf"));
+    }
 }

--- a/crates/ldrs/src/main.rs
+++ b/crates/ldrs/src/main.rs
@@ -4,7 +4,9 @@ use anyhow::Context;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use dotenvy::dotenv;
 use ldrs::cli_schema;
-use ldrs::ldrs_config::config::{parse_dest, parse_src, LdrsParsedConfig};
+use ldrs::ldrs_config::config::{
+    find_unknown_block_keys, parse_dest, parse_src, LdrsParsedConfig,
+};
 use ldrs::ldrs_config::{execute_configs, infer_env_type, parse_yaml_config};
 use ldrs::ldrs_env::get_all_ldrs_env_vars;
 use ldrs::lua_logic::lua_args::{modules_from_args, LuaArgs, SnowflakeResult, SnowflakeStrategy};
@@ -216,9 +218,15 @@ fn main() -> Result<(), anyhow::Error> {
                 let src_default = infer_env_type("LDRS_SRC", &ldrs_env);
                 let dest_default = infer_env_type("LDRS_DEST", &ldrs_env);
                 let src = parse_src(config.clone(), &src_default)?;
-                let dest = parse_dest(config, &dest_default)?;
+                let dest = parse_dest(config.clone(), &dest_default)?;
+                let unknown_keys = find_unknown_block_keys(&config, &src, &dest);
+
                 execute_configs(
-                    vec![LdrsParsedConfig { src, dest }],
+                    vec![LdrsParsedConfig {
+                        src,
+                        dest,
+                        unknown_keys,
+                    }],
                     None,
                     &ldrs_env,
                     &rt.handle(),

--- a/crates/ldrs/src/parquet.rs
+++ b/crates/ldrs/src/parquet.rs
@@ -1,8 +1,12 @@
 use ldrs_arrow::ColumnSpec;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(
+    description = "Parquet destination. Writes a Parquet file to LDRS_DEST + filename via object_store."
+)]
 pub struct ParquetDestination {
     pub name: String,
     pub filename: String,
@@ -17,12 +21,18 @@ impl TryFrom<&Value> for ParquetDestination {
         let name = value
             .get("name")
             .and_then(|v| String::deserialize(v).ok())
-            .ok_or(anyhow::anyhow!("Missing name"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("Missing name for kind pq (see `ldrs schema pq` for required fields)")
+            })?;
         let filename = value
             .get("pq.filename")
             .or(value.get("filename"))
             .and_then(|f| String::deserialize(f).ok())
-            .ok_or_else(|| anyhow::anyhow!("Missing filename"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Missing filename for kind pq (see `ldrs schema pq` for required fields)"
+                )
+            })?;
         let columns = value
             .get("columns")
             .and_then(|c| Vec::<ColumnSpec>::deserialize(c).ok())

--- a/crates/ldrs/src/parquet.rs
+++ b/crates/ldrs/src/parquet.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use ldrs_arrow::ColumnSpec;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,9 @@ impl TryFrom<&Value> for ParquetDestination {
             })?;
         let columns = value
             .get("columns")
-            .and_then(|c| Vec::<ColumnSpec>::deserialize(c).ok())
+            .map(|c| Vec::<ColumnSpec>::deserialize(c))
+            .transpose()
+            .context("failed to parse columns for kind pq")?
             .unwrap_or_default();
         let bloom_filters = value
             .get("bloom_filters")
@@ -47,5 +50,33 @@ impl TryFrom<&Value> for ParquetDestination {
             columns,
             bloom_filters,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_propagates_unknown_column_field_error() {
+        let yaml = r#"
+name: foo
+filename: foo.parquet
+columns:
+  - type: varchar
+    name: id
+    lenght: 32
+"#;
+        let value: Value = serde_yaml::from_str(yaml).unwrap();
+        let err = ParquetDestination::try_from(&value).unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("lenght"),
+            "expected error to mention the bad field, got: {msg}"
+        );
+        assert!(
+            msg.contains("columns"),
+            "expected error to mention the columns context, got: {msg}"
+        );
     }
 }

--- a/crates/ldrs/src/postgres/postgres_destination.rs
+++ b/crates/ldrs/src/postgres/postgres_destination.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use ldrs_arrow::{ColumnSpec, ColumnType};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -20,6 +21,9 @@ pub struct PgDeleteInsert {
     pub role: Option<String>,
     pub columns: Vec<ColumnSpec>,
     pub delete_keys: Vec<String>,
+    #[schemars(
+        description = "Positional column types for the prepared DELETE WHERE clause. Values come from `LDRS_PARAM_*` env vars (positional, lex-sorted by env-var name); the count of types here must match the count of bound values. When present, this overrides per-position type hints from the `LDRS_PARAM_<NAME>_<TYPE>` env-var suffix."
+    )]
     pub param_keys: Option<Vec<ColumnType>>,
 }
 
@@ -226,7 +230,9 @@ pub fn from_serde_yaml(yaml: &Value, tag: Option<&str>) -> Result<PgDestination,
         get_either(yaml, "pg.post_sql", "post_sql").and_then(|v| String::deserialize(v).ok());
     let role = get_either(yaml, "pg.role", "role").and_then(|v| String::deserialize(v).ok());
     let columns = get_either(yaml, "pg.columns", "columns")
-        .and_then(|v| Vec::<ColumnSpec>::deserialize(v).ok())
+        .map(|v| Vec::<ColumnSpec>::deserialize(v))
+        .transpose()
+        .context("failed to parse columns for kind pg")?
         .unwrap_or_default();
     // get discriminators
     let merge_keys = get_either(yaml, "pg.merge_keys", "merge_keys")

--- a/crates/ldrs/src/postgres/postgres_destination.rs
+++ b/crates/ldrs/src/postgres/postgres_destination.rs
@@ -1,8 +1,9 @@
 use ldrs_arrow::{ColumnSpec, ColumnType};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct PgCommon {
     pub name: String,
     pub pre_sql: Option<String>,
@@ -11,7 +12,7 @@ pub struct PgCommon {
     pub columns: Vec<ColumnSpec>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct PgDeleteInsert {
     pub name: String,
     pub pre_sql: Option<String>,
@@ -22,7 +23,7 @@ pub struct PgDeleteInsert {
     pub param_keys: Option<Vec<ColumnType>>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct PgMerge {
     pub name: String,
     pub pre_sql: Option<String>,
@@ -32,7 +33,7 @@ pub struct PgMerge {
     pub merge_keys: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PgPreparedStmt {
     pub stmt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,14 +42,14 @@ pub struct PgPreparedStmt {
     pub types: Option<Vec<ColumnType>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PgMergeConfig {
     pub target: String,
     pub source: String,
     pub keys: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum PgDestCommand {
     CreateTable(String),
@@ -76,8 +77,11 @@ pub fn validate_execution_plan(commands: &[PgDestCommand]) -> Result<(), anyhow:
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "dest")]
+#[schemars(
+    description = "PostgreSQL destination. Writes rows to LDRS_DEST using the chosen sub-kind: merge / drop_replace / truncate_insert / delete_insert."
+)]
 pub enum PgDestination {
     #[serde(rename = "pg.drop_replace")]
     DropReplace(PgCommon),
@@ -212,7 +216,9 @@ pub fn from_serde_yaml(yaml: &Value, tag: Option<&str>) -> Result<PgDestination,
     let name = yaml
         .get("name")
         .and_then(|v| String::deserialize(v).ok())
-        .ok_or(anyhow::anyhow!("Missing name"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("Missing name for kind pg (see `ldrs schema pg` for required fields)")
+        })?;
     // get common values
     let pre_sql =
         get_either(yaml, "pg.pre_sql", "pre_sql").and_then(|v| String::deserialize(v).ok());

--- a/crates/ldrs/tests/delta_integration.rs
+++ b/crates/ldrs/tests/delta_integration.rs
@@ -1,6 +1,6 @@
 use delta_kernel::expressions::Scalar;
 use futures::TryStreamExt;
-use ldrs::ldrs_config::create_ldrs_exec;
+use ldrs::ldrs_config::{execute_configs, parse_yaml_config};
 use ldrs_delta::{delta_stats_to_json, overwrite_delta, parquet_metadata_to_delta_stats};
 use ldrs_parquet::builder_from_string;
 use ldrs_test_fixtures::{data_url, fixture, fixture_url};
@@ -445,9 +445,14 @@ tables:
         .build()
         .unwrap();
 
-    create_ldrs_exec(config, &ldrs_env, None, &rt.handle())
-        .await
-        .unwrap();
+    execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await
+    .unwrap();
 
     for name in &table_names {
         let delta_table = format!("{}/{}/", delta_root, name);
@@ -542,9 +547,14 @@ tables:
         .unwrap();
 
     // First run: creates the table (v0) and commits the initial merge (v1)
-    create_ldrs_exec(config, &ldrs_env, None, &rt.handle())
-        .await
-        .unwrap();
+    execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await
+    .unwrap();
 
     let v0_path = format!("{}_delta_log/00000000000000000000.json", table_path);
     let v1_path = format!("{}_delta_log/00000000000000000001.json", table_path);
@@ -578,9 +588,14 @@ tables:
     assert_eq!(v1_removes, 0, "first merge on empty table has no removes");
 
     // Second run: same source, same keys, so all rows match → DV path
-    create_ldrs_exec(config, &ldrs_env, None, &rt.handle())
-        .await
-        .unwrap();
+    execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await
+    .unwrap();
 
     let v2_path = format!("{}_delta_log/00000000000000000002.json", table_path);
     assert!(

--- a/crates/ldrs/tests/parquet_integration.rs
+++ b/crates/ldrs/tests/parquet_integration.rs
@@ -77,7 +77,11 @@ pq.filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
     let test_value: Value = serde_yaml::from_str(test_yaml).unwrap();
     let src = parse_src(test_value.clone(), &Some("file".into())).unwrap();
     let dest = parse_dest(test_value, &Some("pq".into())).unwrap();
-    let config = LdrsParsedConfig { src, dest };
+    let config = LdrsParsedConfig {
+        src,
+        dest,
+        unknown_keys: Vec::new(),
+    };
     let expected_config = LdrsParsedConfig {
         src: LdrsSource::File(FileSource {
             name: "public.users".into(),
@@ -89,6 +93,7 @@ pq.filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
             columns: Vec::new(),
             bloom_filters: Vec::new(),
         }),
+        unknown_keys: Vec::new(),
     };
     assert_eq!(config, expected_config);
 
@@ -102,7 +107,11 @@ filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
     let test_value: Value = serde_yaml::from_str(sf_yaml).unwrap();
     let src = parse_src(test_value.clone(), &Some("sf".into())).unwrap();
     let dest = parse_dest(test_value, &Some("pq".into())).unwrap();
-    let config = LdrsParsedConfig { src, dest };
+    let config = LdrsParsedConfig {
+        src,
+        dest,
+        unknown_keys: Vec::new(),
+    };
     let expected_config = LdrsParsedConfig {
         src: LdrsSource::SF(SFSource::Query(SFQuery {
             name: "public.users".into(),
@@ -115,6 +124,7 @@ filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
             columns: Vec::new(),
             bloom_filters: Vec::new(),
         }),
+        unknown_keys: Vec::new(),
     };
     assert_eq!(config, expected_config);
 }

--- a/crates/ldrs/tests/parquet_integration.rs
+++ b/crates/ldrs/tests/parquet_integration.rs
@@ -6,8 +6,8 @@ use futures::TryStreamExt;
 use ldrs::{
     file_source::FileSource,
     ldrs_config::{
-        config::{get_parsed_config, LdrsDestination, LdrsParsedConfig, LdrsSource},
-        create_ldrs_exec,
+        config::{parse_dest, parse_src, LdrsDestination, LdrsParsedConfig, LdrsSource},
+        execute_configs, parse_yaml_config,
     },
     ldrs_snowflake::snowflake_source::{SFQuery, SFSource},
     parquet::ParquetDestination,
@@ -15,6 +15,7 @@ use ldrs::{
 use ldrs_arrow::{build_arrow_transform_strategy, ColumnType};
 use ldrs_parquet::{builder_from_string, write_parquet, write_parquet_split};
 use ldrs_test_fixtures::{data_url, fixture, fixture_str};
+use serde_yaml::Value;
 use tracing::info;
 
 const TEST_CASES: &[(&str, &str)] = &[
@@ -73,28 +74,21 @@ name: public.users
 pq.filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
 "#;
 
-    let test_value = serde_yaml::from_str(test_yaml).unwrap();
-    let config = get_parsed_config(
-        &Some("file".into()),
-        &Some("pq".into()),
-        &None,
-        &None,
-        test_value,
-    )
-    .unwrap();
+    let test_value: Value = serde_yaml::from_str(test_yaml).unwrap();
+    let src = parse_src(test_value.clone(), &Some("file".into())).unwrap();
+    let dest = parse_dest(test_value, &Some("pq".into())).unwrap();
+    let config = LdrsParsedConfig { src, dest };
     let expected_config = LdrsParsedConfig {
         src: LdrsSource::File(FileSource {
             name: "public.users".into(),
             filename: None,
         }),
-        src_prefix: "file".into(),
         dest: LdrsDestination::Pq(ParquetDestination {
             name: "public.users".into(),
             filename: "tests/test_data/parquet_writes/public.users.written.snappy.parquet".into(),
             columns: Vec::new(),
             bloom_filters: Vec::new(),
         }),
-        dest_prefix: "pq".into(),
     };
     assert_eq!(config, expected_config);
 
@@ -105,29 +99,22 @@ sql: select * from users
 filename: tests/test_data/parquet_writes/public.users.written.snappy.parquet
 "#;
 
-    let test_value = serde_yaml::from_str(sf_yaml).unwrap();
-    let config = get_parsed_config(
-        &Some("sf".into()),
-        &Some("pq".into()),
-        &None,
-        &None,
-        test_value,
-    )
-    .unwrap();
+    let test_value: Value = serde_yaml::from_str(sf_yaml).unwrap();
+    let src = parse_src(test_value.clone(), &Some("sf".into())).unwrap();
+    let dest = parse_dest(test_value, &Some("pq".into())).unwrap();
+    let config = LdrsParsedConfig { src, dest };
     let expected_config = LdrsParsedConfig {
         src: LdrsSource::SF(SFSource::Query(SFQuery {
             name: "public.users".into(),
             sql: "select * from users".into(),
             param_keys: None,
         })),
-        src_prefix: "sf".into(),
         dest: LdrsDestination::Pq(ParquetDestination {
             name: "public.users".into(),
             filename: "tests/test_data/parquet_writes/public.users.written.snappy.parquet".into(),
             columns: Vec::new(),
             bloom_filters: Vec::new(),
         }),
-        dest_prefix: "pq".into(),
     };
     assert_eq!(config, expected_config);
 }
@@ -169,9 +156,14 @@ tables:
     for file in &expected_files {
         let _ = std::fs::remove_file(file);
     }
-    let _ = create_ldrs_exec(config, &ldrs_env, None, &rt.handle())
-        .await
-        .unwrap();
+    execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await
+    .unwrap();
     // ensure the expected files exist
     for file in &expected_files {
         assert!(

--- a/crates/ldrs/tests/postgres_integration.rs
+++ b/crates/ldrs/tests/postgres_integration.rs
@@ -1,6 +1,6 @@
-use ldrs::ldrs_config::create_ldrs_exec;
+use ldrs::ldrs_config::{execute_configs, parse_yaml_config};
 use ldrs_postgres::create_connection;
-use ldrs_test_fixtures::{data_dir, data_url};
+use ldrs_test_fixtures::data_url;
 
 const TEST_CASES: &[&str] = &[
     "
@@ -87,7 +87,13 @@ async fn test_postgres_file_drop() {
     for config in TEST_CASES {
         let client = create_connection(pg_url).await.unwrap();
         let _ = client.batch_execute("DROP SCHEMA IF EXISTS public_test CASCADE");
-        let ex = create_ldrs_exec(config, &ldrs_env, None, &rt.handle()).await;
+        let ex = execute_configs(
+            parse_yaml_config(&config, &ldrs_env).unwrap(),
+            None,
+            &ldrs_env,
+            &rt.handle(),
+        )
+        .await;
         assert_eq!(ex.is_ok(), true);
 
         let users = client
@@ -111,6 +117,13 @@ async fn test_postgres_file_drop() {
 
 #[tokio::test]
 async fn test_postgres_env_role() {
+    let config = "
+src: file
+dest: pg.drop_replace
+tables:
+  - name: public_test.users
+    filename: public.users/public.users.snappy.parquet
+      ";
     let file_url = data_url();
     let pg_url = "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     let ldrs_env = vec![
@@ -127,8 +140,21 @@ async fn test_postgres_env_role() {
         .enable_all()
         .build()
         .unwrap();
-    let ex = create_ldrs_exec("", &ldrs_env, None, &rt.handle()).await;
+    let ex = execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await;
     assert!(ex.is_err());
+    let ex_err = ex.unwrap_err();
+    let msg = format!("{:?}", ex_err); // Debug walks the whole anyhow chain, not just top-level
+    assert!(
+        msg.contains("non_existent_role"),
+        "expected role error, got: {}",
+        msg,
+    );
     tokio::runtime::Handle::current().spawn_blocking(move || drop(rt));
 }
 
@@ -167,7 +193,13 @@ tables:
         .await;
     let _ = client.batch_execute("CREATE SCHEMA public_test_all").await;
 
-    let ex = create_ldrs_exec(config, &ldrs_env, None, &rt.handle()).await;
+    let ex = execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await;
     assert!(ex.is_ok(), "ldrs exec should succeed: {:?}", ex.err());
 
     for table in ["users", "strings", "numbers"] {
@@ -265,7 +297,13 @@ tables:
         .await;
     let _ = client.batch_execute("CREATE SCHEMA public_test_edge").await;
 
-    let ex = create_ldrs_exec(config, &ldrs_env, None, &rt.handle()).await;
+    let ex = execute_configs(
+        parse_yaml_config(&config, &ldrs_env).unwrap(),
+        None,
+        &ldrs_env,
+        &rt.handle(),
+    )
+    .await;
     assert!(ex.is_ok(), "ldrs exec should succeed: {:?}", ex.err());
 
     // Edge cases covering PgFixedNumeric branches not exercised by the main fixture:


### PR DESCRIPTION
Created two new commands. run for one off queries that can output Arrow to stdout. This is not required, but makes ldrs easily piped into other shell commands. 

To do this I refactored how we build and parse the configs and execute them. This also lead to some validation of the configs. For the most part they are very flexible, but this also allows you to create configs you think are correct, but are not. So we now warn on keys that do not apply to anything.